### PR TITLE
Slight change to narrative template

### DIFF
--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -80,7 +80,6 @@
                 {{/each}}
             </div>
         </div>
-        {{#unless _mobile}}
         <div class="narrative-content">
             <div class="inner">
                 {{#each items}}
@@ -99,6 +98,5 @@
                 {{/each}}
             </div>
         </div>
-        {{/unless}}
     </div>    
 </div>


### PR DESCRIPTION
When resizing the narrative and moving from a small to a medium viewport,
the narrative text would not appear.  I've removed the conditional mobile
check on the template as the JS handles this anyway and to ensure that the
behaviour is as expected when viewed on a non mobile device.
