### PR TITLE
Fixing breakpoint issue with the view

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-narrative",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "authors": [
     "Brian Quinn <brian@learningpool.com>",

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -118,6 +118,7 @@ define(function(require) {
             if (this.model.get('_wasHotgraphic') && Adapt.device.screenSize == 'large') {
                 this.replaceWithHotgraphic();
             }
+            this.resizeControl();
         },
 
         closeNotify: function() {

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -117,8 +117,9 @@ define(function(require) {
         reRender: function() {
             if (this.model.get('_wasHotgraphic') && Adapt.device.screenSize == 'large') {
                 this.replaceWithHotgraphic();
+            } else {
+                this.resizeControl();
             }
-            this.resizeControl();
         },
 
         closeNotify: function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-narrative",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A narrative component",
   "main": "",
   "scripts": {


### PR DESCRIPTION
If you resize the screen making it smaller the breakpoint for the view change from desktop to mobile happened at 758px. Whereas if you resize the screen making it bigger the breakpoint for the view change from mobile to desktop happened at 761px.

This creates an issue with a few pixels not syncing up with the normal breakpoints. Small issue but breaks layout on some devices that fall in to these breakpoints when changing orientation.