### PR TITLE
Remove impediment to mobileInstruction.

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -129,9 +129,9 @@ define(function(require) {
 
         replaceInstructions: function() {
             if (Adapt.device.screenSize === 'large') {
-                this.$('.narrative-instruction-inner').children('span').html(this.model.get('instruction'));
+                this.$('.narrative-instruction-inner').html(this.model.get('instruction'));
             } else if (this.model.get('mobileInstruction') && !this.model.get('_wasHotgraphic')) {
-                this.$('.narrative-instruction-inner').children('span').html(this.model.get('mobileInstruction'));
+                this.$('.narrative-instruction-inner').html(this.model.get('mobileInstruction'));
             }
         },
 


### PR DESCRIPTION
Addresses #118. Removed children('span') from replaceInstruction(). Was preventing mobileInstruction from displaying. partials/component.hbs has no span tags.