### PR TITLE
remove _graphic.title from example.json

### DIFF
--- a/example.json
+++ b/example.json
@@ -18,8 +18,7 @@
                 "body": "This is display text 1. If viewing on desktop or tablet, this text will appear to the right of the image. On mobile, you’ll need to select the plus icon to reveal this text.",
                 "_graphic": {
                     "src": "course/en/images/image-slider-1.jpg",
-                    "alt": "First graphic",
-                    "title": "First graphic"
+                    "alt": "First graphic"
                 },
                 "strapline": "Here is the first..."
             },
@@ -28,8 +27,7 @@
                 "body": "This is display text 2.",
                 "_graphic": {
                     "src": "course/en/images/image-slider-2.jpg",
-                    "alt": "Second graphic",
-                    "title": "Second graphic"
+                    "alt": "Second graphic"
                 },
                 "strapline": "Now comes the second..."
             },
@@ -38,8 +36,7 @@
                 "body": "This is display text 3.",
                 "_graphic": {
                     "src": "course/en/images/image-slider-3.jpg",
-                    "alt": "Third graphic",
-                    "title": "Third graphic"
+                    "alt": "Third graphic"
                 },
                 "strapline": "Third here!"
             }

--- a/properties.schema
+++ b/properties.schema
@@ -94,15 +94,6 @@
                 "inputType": "Text",
                 "validators": [],
                 "help": "Alternative text for this items image"
-              },
-              "title": {
-                "type":"string",
-                "required": false,
-                "default": "",
-                "title": "Graphic title",
-                "inputType": "Text",
-                "validators": [],
-                "help": "This setting is for the title attribute on the image"
               }
             }
           },


### PR DESCRIPTION
Remove '_graphic.title' from example.json. 
'_graphic.title' doesn't appear to be referenced by js or hbs. Use of '_graphic.title' is inconsistent with other components where it is not used.

Also removed it from properties.schema.