### PR TITLE
Fix for mobile component switch

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -144,8 +144,9 @@ define(function(require) {
             
             var model = this.prepareHotgraphicModel();
             var newHotgraphic = new Hotgraphic({ model: model });
+            var $container = $(".component-container", $("." + this.model.get("_parentId")));
 
-            $("." + this.model.get("_parentId")).append(newHotgraphic.$el);
+            $container.append(newHotgraphic.$el);
             this.remove();
             _.defer(function() {
                 Adapt.trigger('device:resize');


### PR DESCRIPTION
Fix for when the narrative switches to a hotgraphic component for mobile view. Component now gets appended to the 'component-container' div rather than outside of it.