### PR TITLE
Hotfix to hide first / last arrows

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -178,6 +178,9 @@
             margin: (@icon-size/2);
             color:@button-text-color;
         }
+        &.narrative-hidden {
+            display: none;
+        }
     }
 
     .narrative-control-left {


### PR DESCRIPTION
Added the narrative-hidden class to narrative-controls so the first and last arrows of the narrative are hidden.