### PR TITLE
Navigate by clicking the progress indicator dots

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -317,7 +317,7 @@ define(function(require) {
             stage = (stage + numberOfItems) % numberOfItems;
             this.setStage(stage);
         },
-        onBtnClicked: function(event) {
+        onProgressClicked: function(event) {
             event.preventDefault();
             var clickedIndex = $(event.target).index();
             this.setStage(clickedIndex);

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -7,7 +7,8 @@ define(function(require) {
 
         events: {
             'click .narrative-strapline-title': 'openPopup',
-            'click .narrative-controls': 'onNavigationClicked'
+            'click .narrative-controls': 'onNavigationClicked',
+            'click .narrative-indicators .narrative-progress': 'onProgressClicked'
         },
 
         preRender: function() {
@@ -315,6 +316,11 @@ define(function(require) {
             }
             stage = (stage + numberOfItems) % numberOfItems;
             this.setStage(stage);
+        },
+        onBtnClicked: function(event) {
+            event.preventDefault();
+            var clickedIndex = $(event.target).index();
+            this.setStage(clickedIndex);
         },
 
         inview: function(event, visible, visiblePartX, visiblePartY) {

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -317,6 +317,7 @@ define(function(require) {
             stage = (stage + numberOfItems) % numberOfItems;
             this.setStage(stage);
         },
+        
         onProgressClicked: function(event) {
             event.preventDefault();
             var clickedIndex = $(event.target).index();

--- a/less/narrative.less
+++ b/less/narrative.less
@@ -143,8 +143,9 @@
     }
 
     .narrative-progress {
-        width: (@icon-size/3);
-        height: (@icon-size/3);
+        cursor: pointer;
+        width: (@icon-size/2);
+        height: (@icon-size/2);
         display: inline-block;
         background-color: @item-color;
         border:1px solid @foreground-color;


### PR DESCRIPTION
This PR allows the learner to navigate through the narrative slides by clicking the progress dots on the bottom of the slide. This has been tested on IE8 +, FireFox, Chrome and Ipad.