### PR TITLE
Removed padding on strapline title

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -216,7 +216,6 @@
         text-decoration: none;
         background-color: @button-color;
         color: @button-text-color;
-        padding: 10px;
         .dir-rtl & {
             float: right;
         }


### PR DESCRIPTION
Change to fix a bug with strapline title padding adding to overall width of <button> tag which caused a rendering issue.

Strapline title inner has left padding already to counter any problems.

Direct results of <a> to <button> tag change.

Bug appears on small devices.