### PR TITLE
bugfix/accessibility: img tabindex control

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -190,8 +190,6 @@ define(function(require) {
             this.$('.narrative-progress:visible').removeClass('selected').eq(stage).addClass('selected');
             this.$('.narrative-slider-graphic').children('.controls').a11y_cntrl_enabled(false);
             this.$('.narrative-slider-graphic').eq(stage).children('.controls').a11y_cntrl_enabled(true);
-            this.$('.narrative-slider-graphic').children('img').a11y_cntrl_enabled(false);
-            this.$('.narrative-slider-graphic').eq(stage).children('img').a11y_cntrl_enabled(true);
             this.$('.narrative-content-item').addClass('narrative-hidden').a11y_on(false).eq(stage).removeClass('narrative-hidden').a11y_on(true);
             this.$('.narrative-strapline-title').a11y_cntrl_enabled(false).eq(stage).a11y_cntrl_enabled(true);
 

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -190,6 +190,8 @@ define(function(require) {
             this.$('.narrative-progress:visible').removeClass('selected').eq(stage).addClass('selected');
             this.$('.narrative-slider-graphic').children('.controls').a11y_cntrl_enabled(false);
             this.$('.narrative-slider-graphic').eq(stage).children('.controls').a11y_cntrl_enabled(true);
+            this.$('.narrative-slider-graphic').children('img').a11y_cntrl_enabled(false);
+            this.$('.narrative-slider-graphic').eq(stage).children('img').a11y_cntrl_enabled(true);
             this.$('.narrative-content-item').addClass('narrative-hidden').a11y_on(false).eq(stage).removeClass('narrative-hidden').a11y_on(true);
             this.$('.narrative-strapline-title').a11y_cntrl_enabled(false).eq(stage).a11y_cntrl_enabled(true);
 

--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -6,7 +6,7 @@
         <div class="narrative-content">
             <div class="narrative-content-inner">
                 {{#each _items}}
-                <div class="narrative-content-item">
+                <div class="narrative-content-item" aria-label="{{_graphic.alt}}">
                     <div class="narrative-content-title">
                         <div class="narrative-content-title-inner accessible-text-block h5" role="heading" aria-level="5" tabindex="0">
                             {{{title}}} 
@@ -64,7 +64,7 @@
             <div class="narrative-slider clearfix">
                 {{#each _items}}
                 <div class="narrative-slider-graphic {{#if visited}}visited{{/if}}">
-                    <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}" tabindex="0"/>
+                    <img src="{{_graphic.src}}" alt="{{_graphic.alt}}""/>
                 </div>
                 {{/each}}
             </div>

--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -64,7 +64,7 @@
             <div class="narrative-slider clearfix">
                 {{#each _items}}
                 <div class="narrative-slider-graphic {{#if visited}}visited{{/if}}">
-                    <img src="{{_graphic.src}}" alt="{{_graphic.alt}}""/>
+                    <img src="{{_graphic.src}}" alt="{{_graphic.alt}}"/>
                 </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
removed image tabindexes and injected the image alt tag as a tabbable area before the title.