### PR TITLE
Hide next button when there is one slide only

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -230,7 +230,7 @@ define(function(require) {
             var currentStage = this.model.get('_stage');
             var itemCount = this.model.get('_itemCount');
             if (currentStage == 0) {
-                this.$('.narrative-control-left').addClass('narrative-hidden');
+                this.$('.narrative-controls').addClass('narrative-hidden');
 
                 if (itemCount > 1) {
                     this.$('.narrative-control-right').removeClass('narrative-hidden');


### PR DESCRIPTION
This hide the next button as well as the prev button when there is one slide only!!
Fixes issue https://github.com/adaptlearning/adapt-contrib-narrative/issues/151