### PR TITLE
fixes ABU-1142

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -115,6 +115,7 @@ define(function(require) {
 
         resizeControl: function() {
             this.setDeviceSize();
+            _.once(this.replaceInstructions);
             this.calculateWidths();
             this.evaluateNavigation();
         },
@@ -123,7 +124,7 @@ define(function(require) {
             if (this.model.get('_wasHotgraphic') && Adapt.device.screenSize == 'large') {
                 this.replaceWithHotgraphic();
             } else {
-                this.resizeControl();
+                this.replaceInstructions();
             }
         },
 

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -115,7 +115,6 @@ define(function(require) {
 
         resizeControl: function() {
             this.setDeviceSize();
-            this.replaceInstructions();
             this.calculateWidths();
             this.evaluateNavigation();
         },


### PR DESCRIPTION
.accessibility-state span gets removed and Re-added,
from pre render resizeControl is calling twice replaceInstructions  that's why tabindex value is not updated it is Re-added, due to this The focus returns to the top of the page, then to the instruction text on the narrative component, and then finally on to the close button within the hotgraphic popup.