### PR TITLE
Tabbing fixes for ABU-1142

### DIFF
--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -150,6 +150,7 @@ define(function(require) {
 
             $container.append(newHotgraphic.$el);
             this.remove();
+            $.a11y_update();
             _.defer(function() {
                 Adapt.trigger('device:resize');
             });

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -95,7 +95,6 @@ define(function(require) {
             var marginRight = this.$('.narrative-slider-graphic').css('margin-right');
             var extraMargin = marginRight === '' ? 0 : parseInt(marginRight);
             var fullSlideWidth = (slideWidth + extraMargin) * slideCount;
-            var iconWidth = this.$('.narrative-popup-open').outerWidth();
 
             this.$('.narrative-slider-graphic').width(slideWidth);
             this.$('.narrative-strapline-header').width(slideWidth);
@@ -114,8 +113,9 @@ define(function(require) {
         },
 
         resizeControl: function() {
+            var wasDesktop = this.model.get('_isDesktop');
             this.setDeviceSize();
-            this.replaceInstructions();
+            if (wasDesktop != this.model.get('_isDesktop')) this.replaceInstructions();
             this.calculateWidths();
             this.evaluateNavigation();
         },
@@ -200,7 +200,7 @@ define(function(require) {
                 if (this.model.get('_isDesktop')) {
                     if (!initial) this.$('.narrative-content-item').eq(stage).a11y_focus();
                 } else {
-                    if (!initial) this.$('.narrative-popup-open').a11y_focus();
+                    if (!initial) this.$('.narrative-strapline-title').a11y_focus();
                 }
             }, this));
         },


### PR DESCRIPTION
This should resolve the issue described in ABU-1142. From my testing there seemed to be multiple related issues, but these should be resolved with this PR. One thing to note, when a narrative is replaced with its original hot graphic component (when resizing the browser window from mobile size back to desktop size), the component-inner div carries the aria-label and tabindex attributes because a11y_update hasn't run. This means that when the hot graphic popup is opened the inner div ends up in the tabbing order. When the popup is closed a11y_update is run and this issue appears no more. Obviously just sticking in a call to a11y_update when the narrative is replaced by the hotgraphic will fix this, but can someone advise if this is the right way to go? Thanks.