### PR TITLE
Corrects #1112, iOS issue with clicking narrative-slider-graphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The attributes listed below are used in *components.json* to configure **Narrati
 On mobile devices, the narrative text is collapsed above the image. It is accessed by clicking an icon (+) next the to strapline.
 
 ----------------------------
-**Version number:**  2.0.4   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.0.5   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 2.0  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-narrative",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-narrative%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -64,7 +64,7 @@
             <div class="narrative-slider clearfix">
                 {{#each _items}}
                 <div class="narrative-slider-graphic {{#if _isVisited}}visited{{/if}}">
-                    <img src="{{_graphic.src}}" alt="{{_graphic.alt}}"/>
+                    <img src="{{_graphic.src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}" tabindex="0"{{else}}class="a11y-ignore" aria-hidden="true" tabindex="-1"{{/if}}/>
                 </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
This was caused by a missing tabindex attribute.