### PR TITLE
Fixes tabbing issue

### DIFF
--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -64,7 +64,7 @@
             <div class="narrative-slider clearfix">
                 {{#each _items}}
                 <div class="narrative-slider-graphic {{#if _isVisited}}visited{{/if}}">
-                    <img src="{{_graphic.src}}" tabindex="-1" class="a11y-ignore">
+                    <img src="{{_graphic.src}}" tabindex="-1" class="a11y-ignore"/>
                 </div>
                 {{/each}}
             </div>

--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -64,7 +64,7 @@
             <div class="narrative-slider clearfix">
                 {{#each _items}}
                 <div class="narrative-slider-graphic {{#if _isVisited}}visited{{/if}}">
-                    <img src="{{_graphic.src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}" tabindex="0"{{else}}class="a11y-ignore" aria-hidden="true" tabindex="-1"{{/if}}/>
+                    <img src="{{_graphic.src}}" tabindex="-1" class="a11y-ignore">
                 </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
Issue caused by https://github.com/adaptlearning/adapt-contrib-narrative/commit/36e31c1f21c802dea794328ebd78f9fc6ec869bc affects tab order, making images in narrative items tabbable.

This update removes the images from the tab order, which should now be:
1. Component title
2. Component body
3. Component instruction
4. Image label
5. Content title
6. Content body
7. Previous button (if available, loop to 4 if clicked)
8. Next button (if available, loop to 4 if clicked)
9. Component state
