### PR TITLE
Option for all content area's to be the height of the tallest created

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 **_hasNavigationInTextArea** (boolean): Determines the location of the arrows (icons) used to navigate from slide to slide. Navigation can overlay the image or the text. Set to `true` to have the navigation controls appear in the text region.
 
+**__hasFixedHeightContentArea** (boolean): If true the body area for each item will be the height of the tallest one.
+
 **_setCompletionOn** (string): This value determines when the component registers as complete. Acceptable values are `"allItems"` and `"inview"`. `"allItems"` requires the learner to navigate to each slide. `"inview"` requires the **Narrative** component to enter the view port completely, top and bottom.
 
 **_items** (array): Multiple items may be created. Each item represents one slide and contains values for the narrative (**title**, **body**), the image (**_graphic**), and the slide's header when viewed on a mobile device (**_strapLine**).

--- a/example.json
+++ b/example.json
@@ -10,6 +10,7 @@
         "body": "This is optional body text. Select the forward arrows to move through the narrative on a desktop, or swipe the images and select the plus icons to do so on mobile.",
         "instruction": "",
         "_hasNavigationInTextArea": false,
+        "_hasFixedHeightContentArea": false,
         "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
         "_setCompletionOn":"allItems",
         "_items": [

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -33,6 +33,11 @@ define(function(require) {
 
         postRender: function() {
             this.renderState();
+
+            if(this.model.get('_hasFixedHeightContentArea')){
+                this.setContentAreaHeights();
+            }
+
             this.$('.narrative-slider').imageready(_.bind(function() {
                 this.setReadyStatus();
             }, this));
@@ -345,6 +350,18 @@ define(function(require) {
             } else {
                 this.$('.component-widget').on('inview', _.bind(this.inview, this));
             }
+        },
+
+        setContentAreaHeights: function () {
+            var maxHeight = 0;
+            var $contentAreas = this.$('.narrative-content-body');
+            $contentAreas.each(function() {
+                if($(this).height() > maxHeight){
+                    maxHeight = $(this).height();
+                }
+            });
+
+            $contentAreas.height(maxHeight)
         }
 
     });

--- a/properties.schema
+++ b/properties.schema
@@ -49,6 +49,15 @@
       "validators": [],
       "help": "If enabled, all navigation elements will be moved to the text area"
     },
+    "_hasFixedHeightContentArea": {
+      "type": "boolean",
+      "required": true,
+      "default": false,
+      "title": "Fixed Height Content Area",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "If enabled, all content areas will be the height of the tallest one"
+    },
     "_setCompletionOn": {
       "type": "string",
       "required": true,


### PR DESCRIPTION
This gives an option for all content areas to be the same height. This defaults to false so any existing components won't be affected.