### PR TITLE
issue/2506 allow no title

### DIFF
--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -6,11 +6,13 @@
             <div class="narrative-content-inner">
                 {{#each _items}}
                 <div class="narrative-content-item {{#if _isVisited}}visited{{/if}}" data-index="{{@index}}">
+                    {{#if title}}
                     <div class="narrative-content-title">
                         <div class="narrative-content-title-inner" {{a11y_attrs_heading 'componentItem'}}>
                             {{{title}}}
                         </div>
                     </div>
+                    {{/if}}
                     {{#if _graphic.alt}}{{{a11y_aria_image _graphic.alt}}}{{/if}}
                     <div class="narrative-content-body">
                         <div class="narrative-content-body-inner">


### PR DESCRIPTION
[#2506](https://github.com/adaptlearning/adapt_framework/issues/2506)
* remove heading div when no title is specified