### PR TITLE
ADAPT-7825 - Narrative component - narrative strapline button issues on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# adapt-contrib-narrative
+# adapt-contrib-narrative<br>
 
-**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
+**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).__
 
 <img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/narrative01.gif" alt="narrative in action">
 
@@ -13,16 +13,22 @@
 As one of Adapt's *[core components](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#components),* **Narrative** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
 
 * If **Narrative** has been uninstalled from the Adapt framework, it may be reinstalled.
-With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:
-`adapt install adapt-contrib-narrative`
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:<br>
+```console
+adapt install adapt-contrib-narrative
+```
 
-    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:
-    `"adapt-contrib-narrative": "*"`
-    Then running the command:
-    `adapt install`
-    (This second method will reinstall all plug-ins listed in *adapt.json*.)
+Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:<br>
+```json
+"adapt-contrib-narrative": "*"
+```
+Then running the command:<br>
+```console
+adapt install
+```
+(This second method will reinstall all plug-ins listed in *adapt.json*.)
 
-* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).
+* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).<br>
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Settings Overview
@@ -39,9 +45,9 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 **\_layout** (string): This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`; however, `full` is typically the only option used as `left` or `right` do not allow much room for the component to display.
 
-**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.
+**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.<br>
 
-**mobileInstruction** (string): This is optional instruction text that will be shown when viewed on mobile. It may be used to guide the learner’s interaction with the component.
+**mobileInstruction** (string): This is optional instruction text that will be shown when viewed on mobile. It may be used to guide the learner’s interaction with the component.<br>
 
 **\_hasNavigationInTextArea** (boolean): Determines the location of the arrows (icons) used to navigate from slide to slide. Navigation can overlay the image or the text. Set to `true` to have the navigation controls appear in the text region.
 
@@ -61,10 +67,10 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 >>**attribution** (string): Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
 
->**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).
+>**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).<br>
 
-### Accessibility
-**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).
+### Accessibility<br>
+**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).<br>
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
@@ -72,9 +78,9 @@ The attributes listed below are used in *components.json* to configure **Narrati
 On mobile devices, the narrative text is collapsed above the image. It is accessed by clicking an icon (+) next the to strapline.
 
 ----------------------------
-**Version number:**  6.2.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Framework versions:** 5.5+
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera
+**Version number:**  6.2.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a><br>
+**Framework versions:** 5.5+<br>
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 As one of Adapt's *[core components](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#components),* **Narrative** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
 
 * If **Narrative** has been uninstalled from the Adapt framework, it may be reinstalled.
-With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:<br>
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:
   ```console
   adapt install adapt-contrib-narrative
   ```

--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ On mobile devices, the narrative text is collapsed above the image. It is access
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera<br>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adapt-contrib-narrative<br>
 
-**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).__
+**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).<br>
 
 <img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/narrative01.gif" alt="narrative in action">
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# adapt-contrib-narrative<br>
+# adapt-contrib-narrative
 
 **Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).<br>
 
@@ -44,9 +44,9 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 **\_layout** (string): This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`; however, `full` is typically the only option used as `left` or `right` do not allow much room for the component to display.
 
-**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.<br>
+**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.
 
-**mobileInstruction** (string): This is optional instruction text that will be shown when viewed on mobile. It may be used to guide the learner’s interaction with the component.<br>
+**mobileInstruction** (string): This is optional instruction text that will be shown when viewed on mobile. It may be used to guide the learner’s interaction with the component.
 
 **\_hasNavigationInTextArea** (boolean): Determines the location of the arrows (icons) used to navigate from slide to slide. Navigation can overlay the image or the text. Set to `true` to have the navigation controls appear in the text region.
 
@@ -68,7 +68,7 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 >**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).<br>
 
-### Accessibility<br>
+### Accessibility
 **Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).<br>
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adapt-contrib-narrative
 
-**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).<br>
+**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
 
 <img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/narrative01.gif" alt="narrative in action">
 
@@ -27,7 +27,7 @@ With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run 
   ```
   (This second method will reinstall all plug-ins listed in *adapt.json*.)
 
-* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).<br>
+* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Settings Overview
@@ -66,10 +66,10 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 >>**attribution** (string): Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
 
->**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).<br>
+>**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).
 
 ### Accessibility
-**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).<br>
+**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
@@ -82,4 +82,4 @@ On mobile devices, the narrative text is collapsed above the image. It is access
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera

--- a/README.md
+++ b/README.md
@@ -14,19 +14,18 @@ As one of Adapt's *[core components](https://github.com/adaptlearning/adapt_fram
 
 * If **Narrative** has been uninstalled from the Adapt framework, it may be reinstalled.
 With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:<br>
-```console
-adapt install adapt-contrib-narrative
-```
-
-Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:<br>
-```json
-"adapt-contrib-narrative": "*"
-```
-Then running the command:<br>
-```console
-adapt install
-```
-(This second method will reinstall all plug-ins listed in *adapt.json*.)
+  ```console
+  adapt install adapt-contrib-narrative
+  ```
+  Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:
+  ```json
+  "adapt-contrib-narrative": "*"
+  ```
+  Then running the command:
+  ```console
+  adapt install
+  ```
+  (This second method will reinstall all plug-ins listed in *adapt.json*.)
 
 * If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).<br>
 <div float align=right><a href="#top">Back to Top</a></div>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# adapt-contrib-narrative  
+# adapt-contrib-narrative
 
-**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).  
+**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
 
 <img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/narrative01.gif" alt="narrative in action">
 
@@ -13,16 +13,16 @@
 As one of Adapt's *[core components](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#components),* **Narrative** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
 
 * If **Narrative** has been uninstalled from the Adapt framework, it may be reinstalled.
-With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:  
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:
 `adapt install adapt-contrib-narrative`
 
-    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:  
-    `"adapt-contrib-narrative": "*"`  
-    Then running the command:  
-    `adapt install`  
-    (This second method will reinstall all plug-ins listed in *adapt.json*.)  
+    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:
+    `"adapt-contrib-narrative": "*"`
+    Then running the command:
+    `adapt install`
+    (This second method will reinstall all plug-ins listed in *adapt.json*.)
 
-* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).  
+* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Settings Overview
@@ -39,9 +39,9 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 **\_layout** (string): This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`; however, `full` is typically the only option used as `left` or `right` do not allow much room for the component to display.
 
-**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.   
+**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.
 
-**mobileInstruction** (string): This is optional instruction text that will be shown when viewed on mobile. It may be used to guide the learner’s interaction with the component.   
+**mobileInstruction** (string): This is optional instruction text that will be shown when viewed on mobile. It may be used to guide the learner’s interaction with the component.
 
 **\_hasNavigationInTextArea** (boolean): Determines the location of the arrows (icons) used to navigate from slide to slide. Navigation can overlay the image or the text. Set to `true` to have the navigation controls appear in the text region.
 
@@ -61,10 +61,10 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 >>**attribution** (string): Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
 
->**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).  
+>**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).
 
-### Accessibility  
-**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).   
+### Accessibility
+**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
@@ -72,9 +72,9 @@ The attributes listed below are used in *components.json* to configure **Narrati
 On mobile devices, the narrative text is collapsed above the image. It is accessed by clicking an icon (+) next the to strapline.
 
 ----------------------------
-**Version number:**  6.2.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
-**Framework versions:** 5.5+  
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)  
-**Accessibility support:** WAI AA  
-**RTL support:** Yes  
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera  
+**Version number:**  6.2.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
+**Framework versions:** 5.5+
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)
+**Accessibility support:** WAI AA
+**RTL support:** Yes
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-narrative",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -188,7 +188,7 @@ define([
       const dataIndexAttr = `[data-index='${itemIndex}']`;
       const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
 
-      if(this.isLargeMode()) {
+      if (this.isLargeMode()) {
         Adapt.a11y.focusFirst($elementToFocus);
       }
     }
@@ -200,8 +200,6 @@ define([
       if (this.isLargeMode()) {
         // Set the visited attribute for large screen devices
         item.toggleVisited(true);
-      } else {
-
       }
 
       this.$('.narrative__progress').removeClass('is-selected').filter(indexSelector).addClass('is-selected');

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -190,9 +190,10 @@ define([
         $straplineHeaderElm.one('transitionend', () => {
           this.focusOnNarrativeElement(itemIndex);
         });
-      } else {
-        this.focusOnNarrativeElement(itemIndex);
+        return;
       }
+      
+      this.focusOnNarrativeElement(itemIndex);
     }
 
     focusOnNarrativeElement(itemIndex) {

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -188,8 +188,8 @@ define([
       $straplineHeaderElm.one('transitionend', () => {
         const dataIndexAttr = `[data-index='${itemIndex}']`;
         const $elementToFocus = this.isLargeMode() ?
-        this.$(`.narrative__content-item${dataIndexAttr}`) :
-        this.$(`.narrative__strapline-btn${dataIndexAttr}`);
+          this.$(`.narrative__content-item${dataIndexAttr}`) :
+          this.$(`.narrative__strapline-btn${dataIndexAttr}`);
         Adapt.a11y.focusFirst($elementToFocus);
       });
     }

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -185,8 +185,12 @@ define([
 
       if (this._isInitial) return;
 
-      const $elementToFocus = this.isLargeMode() ? this.$(`.narrative__content-item[data-index="${itemIndex}"]`) : this.$('.narrative__strapline-btn');
-      Adapt.a11y.focusFirst($elementToFocus);
+      const dataIndexAttr = `[data-index='${itemIndex}']`;
+      const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
+
+      if(this.isLargeMode()) {
+        Adapt.a11y.focusFirst($elementToFocus);
+      }
     }
 
     setStage(item) {
@@ -196,6 +200,8 @@ define([
       if (this.isLargeMode()) {
         // Set the visited attribute for large screen devices
         item.toggleVisited(true);
+      } else {
+
       }
 
       this.$('.narrative__progress').removeClass('is-selected').filter(indexSelector).addClass('is-selected');
@@ -230,7 +236,7 @@ define([
 
       const $left = this.$('.narrative__controls-left');
       const $right = this.$('.narrative__controls-right');
-      
+
       const globals = Adapt.course.get('_globals');
 
       const ariaLabelsGlobals = globals._accessibility._ariaLabels;

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -185,7 +185,8 @@ define([
 
       if (this._isInitial) return;
 
-      if ($straplineHeaderElm.css('transitionDuration') !== '0s') {
+      const hasStraplineTransition = !this.isLargeMode() && parseFloat($straplineHeaderElm.css('transitionDuration'));
+      if (hasStraplineTransition) {
         $straplineHeaderElm.one('transitionend', () => {
           this.focusOnNarrativeElement(itemIndex);
         });

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -189,8 +189,8 @@ define([
       if (hasStraplineTransition) {
         $straplineHeaderElm.one('transitionend', () => {
           this.focusOnNarrativeElement(itemIndex);
-          return;
         });
+        return;
       }
 
       this.focusOnNarrativeElement(itemIndex);

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -185,7 +185,7 @@ define([
 
       if (this._isInitial) return;
 
-      const hasStraplineTransition = !this.isLargeMode() && parseFloat($straplineHeaderElm.css('transitionDuration'));
+      const hasStraplineTransition = !this.isLargeMode() && ($straplineHeaderElm.css('transitionDuration') !== '0s');
       if (hasStraplineTransition) {
         $straplineHeaderElm.one('transitionend', () => {
           this.focusOnNarrativeElement(itemIndex);

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -183,11 +183,15 @@ define([
       $sliderElm.css('transform', cssValue);
       $straplineHeaderElm.css('transform', cssValue);
 
-      if (this._isInitial || !this.isLargeMode()) return;
+      if (this._isInitial) return;
 
-      const dataIndexAttr = `[data-index='${itemIndex}']`;
-      const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
-      Adapt.a11y.focusFirst($elementToFocus);
+      $straplineHeaderElm.one('transitionend', () => {
+        const dataIndexAttr = `[data-index='${itemIndex}']`;
+        const $elementToFocus = this.isLargeMode() ?
+        this.$(`.narrative__content-item${dataIndexAttr}`) :
+        this.$(`.narrative__strapline-btn${dataIndexAttr}`);
+        Adapt.a11y.focusFirst($elementToFocus);
+      });
     }
 
     setStage(item) {

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -189,10 +189,10 @@ define([
       if (hasStraplineTransition) {
         $straplineHeaderElm.one('transitionend', () => {
           this.focusOnNarrativeElement(itemIndex);
+          return;
         });
-        return;
       }
-      
+
       this.focusOnNarrativeElement(itemIndex);
     }
 

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -187,10 +187,10 @@ define([
 
       if ($straplineHeaderElm.css('transitionDuration') !== '0s') {
         $straplineHeaderElm.one('transitionend', () => {
-          focusOnNarrativeElement(itemIndex);
+          this.focusOnNarrativeElement(itemIndex);
         });
       } else {
-        focusOnNarrativeElement(itemIndex);
+        this.focusOnNarrativeElement(itemIndex);
       }
     }
 

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -185,10 +185,9 @@ define([
 
       if (this._isInitial) return;
 
-      const dataIndexAttr = `[data-index='${itemIndex}']`;
-      const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
-
       if (this.isLargeMode()) {
+        const dataIndexAttr = `[data-index='${itemIndex}']`;
+        const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
         Adapt.a11y.focusFirst($elementToFocus);
       }
     }

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -185,13 +185,21 @@ define([
 
       if (this._isInitial) return;
 
-      $straplineHeaderElm.one('transitionend', () => {
-        const dataIndexAttr = `[data-index='${itemIndex}']`;
-        const $elementToFocus = this.isLargeMode() ?
-          this.$(`.narrative__content-item${dataIndexAttr}`) :
-          this.$(`.narrative__strapline-btn${dataIndexAttr}`);
-        Adapt.a11y.focusFirst($elementToFocus);
-      });
+      if ($straplineHeaderElm.css('transitionDuration') !== '0s') {
+        $straplineHeaderElm.one('transitionend', () => {
+          focusOnNarrativeElement(itemIndex);
+        });
+      } else {
+        focusOnNarrativeElement(itemIndex);
+      }
+    }
+
+    focusOnNarrativeElement(itemIndex) {
+      const dataIndexAttr = `[data-index='${itemIndex}']`;
+      const $elementToFocus = this.isLargeMode() ?
+        this.$(`.narrative__content-item${dataIndexAttr}`) :
+        this.$(`.narrative__strapline-btn${dataIndexAttr}`);
+      Adapt.a11y.focusFirst($elementToFocus);
     }
 
     setStage(item) {

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -183,13 +183,11 @@ define([
       $sliderElm.css('transform', cssValue);
       $straplineHeaderElm.css('transform', cssValue);
 
-      if (this._isInitial) return;
+      if (this._isInitial || !this.isLargeMode()) return;
 
-      if (this.isLargeMode()) {
-        const dataIndexAttr = `[data-index='${itemIndex}']`;
-        const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
-        Adapt.a11y.focusFirst($elementToFocus);
-      }
+      const dataIndexAttr = `[data-index='${itemIndex}']`;
+      const $elementToFocus = this.$(`.narrative__content-item${dataIndexAttr}`);
+      Adapt.a11y.focusFirst($elementToFocus);
     }
 
     setStage(item) {


### PR DESCRIPTION
Description of issue:

Customer has reported that When testing two modules) on an Iphone 8. She is having issues with the narrative and hot graphic components - when trying to tap the + to expand the text it is greyed out and on some of them the + to expand disappears completely.

This only happens after the first narrative/graphic and is only happening when I do the modules on an Iphone 8, XS, 11 and 12. It's happening on all of them. I've tried on a number of Android and It's not happening. It's an iPhone specific problem.

Linked issue: https://github.com/adaptlearning/adapt_framework/issues/3013