### PR TITLE
Adapt 7865 narrative taking away focus from open text input

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-narrative",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -39,6 +39,29 @@ define([
     onItemsActiveChange(item, _isActive) {
       if (!_isActive) return;
       this.setStage(item);
+      this.setFocus(itemIndex);
+    }
+
+    setFocus(itemIndex) {
+      if (this._isInitial) return;
+      const $straplineHeaderElm = this.$('.narrative__strapline-header-inner');
+      const hasStraplineTransition = !this.isLargeMode() && ($straplineHeaderElm.css('transitionDuration') !== '0s');
+      if (hasStraplineTransition) {
+        $straplineHeaderElm.one('transitionend', () => {
+          this.focusOnNarrativeElement(itemIndex);
+        });
+        return;
+      }
+
+      this.focusOnNarrativeElement(itemIndex);
+    }
+
+    focusOnNarrativeElement(itemIndex) {
+      const dataIndexAttr = `[data-index='${itemIndex}']`;
+      const $elementToFocus = this.isLargeMode() ?
+        this.$(`.narrative__content-item${dataIndexAttr}`) :
+        this.$(`.narrative__strapline-btn${dataIndexAttr}`);
+      Adapt.a11y.focusFirst($elementToFocus);
     }
 
     onItemsVisitedChange(item, _isVisited) {
@@ -117,6 +140,8 @@ define([
       this.renderMode();
       if (previousMode !== this.model.get('_mode')) this.replaceInstructions();
       this.evaluateNavigation();
+      const activeItem = this.model.getActiveItem();
+      if (activeItem) this.setStage(activeItem);
     }
 
     reRender() {
@@ -180,26 +205,6 @@ define([
 
       $sliderElm.css('transform', cssValue);
       $straplineHeaderElm.css('transform', cssValue);
-
-      if (this._isInitial) return;
-
-      const hasStraplineTransition = !this.isLargeMode() && ($straplineHeaderElm.css('transitionDuration') !== '0s');
-      if (hasStraplineTransition) {
-        $straplineHeaderElm.one('transitionend', () => {
-          this.focusOnNarrativeElement(itemIndex);
-        });
-        return;
-      }
-
-      this.focusOnNarrativeElement(itemIndex);
-    }
-
-    focusOnNarrativeElement(itemIndex) {
-      const dataIndexAttr = `[data-index='${itemIndex}']`;
-      const $elementToFocus = this.isLargeMode() ?
-        this.$(`.narrative__content-item${dataIndexAttr}`) :
-        this.$(`.narrative__strapline-btn${dataIndexAttr}`);
-      Adapt.a11y.focusFirst($elementToFocus);
     }
 
     setStage(item) {

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -117,8 +117,6 @@ define([
       this.renderMode();
       if (previousMode !== this.model.get('_mode')) this.replaceInstructions();
       this.evaluateNavigation();
-      const activeItem = this.model.getActiveItem();
-      if (activeItem) this.setStage(activeItem);
     }
 
     reRender() {

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -39,7 +39,7 @@ define([
     onItemsActiveChange(item, _isActive) {
       if (!_isActive) return;
       this.setStage(item);
-      this.setFocus(itemIndex);
+      this.setFocus(item.get('_index'));
     }
 
     setFocus(itemIndex) {


### PR DESCRIPTION
Description of issue:

A bug that affects Android devices only. When trying to answer an open text input question, the keyboard will appear and immediately disappear straight after. This is still occurring after a rebuild of the course.

Steps to replicate:
Using an android device in landscape view e.g. Samsung Galaxy A21, Samsung Galaxy A21, Samsung Galaxy Tab 2, Google Pixel 3a, S10, Galaxy Tab S6, Galaxy Tab S5e, Galaxy Tab S4, Galaxy Tab S3
Launch course with an open text input component and a narrative component.
Access first page.
Scroll down to the open text input question and attempt to answer it.
The keyboard appears then disappears.

Expected Results:
Keyboard should remain on screen until the user dismisses it.

Actual Results:
Keyboard appears and then immediately disappears again.

Resolves https://github.com/adaptlearning/adapt_framework/issues/3030

**I have another solution here if this fix is not suited: https://github.com/adaptlearning/adapt-contrib-narrative/pull/207**