### PR TITLE
Mobile instruction highlighting for interaction error

### DIFF
--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -281,7 +281,7 @@ define([
     evaluateCompletion() {
       if (this.model.areAllItemsCompleted()) {
         this.trigger('allItems');
-        this.$('.narrative__instruction-inner').removeClass('interaction-error');
+        this.$('.narrative__instruction-inner').removeClass('instruction-error');
       }
     }
 

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -233,7 +233,7 @@ define([
 
       this.evaluateNavigation();
       this.evaluateCompletion();
-      this.evaluateInteraction();
+      this.shouldShowInstructionError();
       this.moveSliderToIndex(index);
     }
 
@@ -310,14 +310,12 @@ define([
       this.model.setActiveItem(index);
     }
 
-    evaluateInteraction() {
-      if (this.model.get('_isComplete')) return;
-      const index = this.model.getActiveItem().get('_index');
-      const prevItem = this.model.getItem(index - 1);
-      if (!prevItem >= 1) return;
-      if (!prevItem.get('_isVisited')) {
-        this.$('.narrative__instruction-inner').addClass('interaction-error');
-      }
+    // In mobile view, highlight instruction if user navigates to another
+    // item before completing, in case the strapline is missed
+    shouldShowInstructionError() {
+      const prevItemIndex = this.model.getActiveItem().get('_index') - 1;
+      if (prevItemIndex < 0 || this.model.getItem(prevItemIndex).get('_isVisited')) return;
+      this.$('.narrative__instruction-inner').addClass('instruction-error');
     }
 
     setupEventListeners() {

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -310,8 +310,10 @@ define([
       this.model.setActiveItem(index);
     }
 
-    // In mobile view, highlight instruction if user navigates to another
-    // item before completing, in case the strapline is missed
+  /**
+   * In mobile view, highlight instruction if user navigates to another
+   * item before completing, in case the strapline is missed
+   */
     shouldShowInstructionError() {
       const prevItemIndex = this.model.getActiveItem().get('_index') - 1;
       if (prevItemIndex < 0 || this.model.getItem(prevItemIndex).get('_isVisited')) return;

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -233,6 +233,7 @@ define([
 
       this.evaluateNavigation();
       this.evaluateCompletion();
+      this.evaluateInteraction();
       this.moveSliderToIndex(index);
     }
 
@@ -302,22 +303,20 @@ define([
       let index = this.model.getActiveItem().get('_index');
       $btn.data('direction') === 'right' ? index++ : index--;
       this.model.setActiveItem(index);
-      if (this.model.get('_setCompletionOn') === 'allItems') {
-        const prevItem = this.model.getItem(index - 1);
-        if (!prevItem.get('_isVisited')) {
-          this.$('.narrative__instruction-inner').addClass('interaction-error');
-        }
-      }
     }
 
     onProgressClicked(event) {
       const index = $(event.target).data('index');
       this.model.setActiveItem(index);
-      if (this.model.get('_setCompletionOn') === 'allItems') {
-        const prevItem = this.model.getItem(index - 1);
-        if (!prevItem.get('_isVisited')) {
-          this.$('.narrative__instruction-inner').addClass('interaction-error');
-        }
+    }
+
+    evaluateInteraction() {
+      if (this.model.get('_isComplete')) return;
+      const index = this.model.getActiveItem().get('_index');
+      const prevItem = this.model.getItem(index - 1);
+      if (!prevItem >= 1) return;
+      if (!prevItem.get('_isVisited')) {
+        this.$('.narrative__instruction-inner').addClass('interaction-error');
       }
     }
 

--- a/js/narrativeView.js
+++ b/js/narrativeView.js
@@ -280,6 +280,7 @@ define([
     evaluateCompletion() {
       if (this.model.areAllItemsCompleted()) {
         this.trigger('allItems');
+        this.$('.narrative__instruction-inner').removeClass('interaction-error');
       }
     }
 
@@ -301,11 +302,23 @@ define([
       let index = this.model.getActiveItem().get('_index');
       $btn.data('direction') === 'right' ? index++ : index--;
       this.model.setActiveItem(index);
+      if (this.model.get('_setCompletionOn') === 'allItems') {
+        const prevItem = this.model.getItem(index - 1);
+        if (!prevItem.get('_isVisited')) {
+          this.$('.narrative__instruction-inner').addClass('interaction-error');
+        }
+      }
     }
 
     onProgressClicked(event) {
       const index = $(event.target).data('index');
       this.model.setActiveItem(index);
+      if (this.model.get('_setCompletionOn') === 'allItems') {
+        const prevItem = this.model.getItem(index - 1);
+        if (!prevItem.get('_isVisited')) {
+          this.$('.narrative__instruction-inner').addClass('interaction-error');
+        }
+      }
     }
 
     setupEventListeners() {
@@ -313,7 +326,6 @@ define([
         this.setupInviewCompletion('.component__widget');
       }
     }
-
   }
 
   NarrativeView.template = 'narrative';


### PR DESCRIPTION
For the following proposed enhancement: https://github.com/adaptlearning/adapt_framework/issues/3070

The aim is to make it clearer to users when they haven't interacted with the mobile Narrative / Hot Graphic elements in the correct order, i.e. skipping ahead one or more items before clicking on the strapline and therefore seeing all the content for that item. This could benefit users whether completion is set to `inview` or `allItems`.

Changes assume the `.instruction-error` and `@instruction-error` class and variable are defined in the Vanilla theme. I've also implemented these changes, which can be submitted in another PR if this one is approved.