### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The attributes listed below are used in *components.json* to configure **Narrati
 
 >>**attribution** (string): Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
 
->**strapline** (string): This text is displayed as a title above the image when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).
+>**strapline** (string): This text is displayed as a title above the image when `device.screenSize` is `small` (i.e., when viewed on mobile devices).
 
 ### Accessibility
 **Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "6.5.3",
-  "framework": ">=5.17.2",
+  "framework": ">=5.19.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component" : "narrative",

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -4,7 +4,6 @@ import a11y from 'core/js/a11y';
 import device from 'core/js/device';
 import notify from 'core/js/notify';
 import ComponentView from 'core/js/views/componentView';
-import device from 'core/js/device';
 import MODE from './modeEnum';
 
 class NarrativeView extends ComponentView {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -1,4 +1,8 @@
 import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
+import a11y from 'core/js/a11y';
+import device from 'core/js/device';
+import notify from 'core/js/notify';
 import ComponentView from 'core/js/views/componentView';
 import MODE from './modeEnum';
 
@@ -63,7 +67,7 @@ class NarrativeView extends ComponentView {
     const $elementToFocus = this.isLargeMode() ?
       this.$(`.narrative__content-item${dataIndexAttr}`) :
       this.$(`.narrative__strapline-btn${dataIndexAttr}`);
-    Adapt.a11y.focusFirst($elementToFocus);
+    a11y.focusFirst($elementToFocus);
   }
 
   onItemsVisitedChange(item, _isVisited) {
@@ -72,7 +76,7 @@ class NarrativeView extends ComponentView {
   }
 
   calculateMode() {
-    const mode = Adapt.device.screenSize === 'large' ? MODE.LARGE : MODE.SMALL;
+    const mode = device.screenSize === 'large' ? MODE.LARGE : MODE.SMALL;
     this.model.set('_mode', mode);
   }
 
@@ -92,7 +96,7 @@ class NarrativeView extends ComponentView {
   }
 
   isTextBelowImage() {
-    const isTextBelowImage = (Adapt.device.screenSize === 'large')
+    const isTextBelowImage = (device.screenSize === 'large')
       ? this.model.get('_isTextBelowImage')
       : this.model.get('_isMobileTextBelowImage');
     return Boolean(isTextBelowImage);
@@ -173,7 +177,7 @@ class NarrativeView extends ComponentView {
   }
 
   replaceWithHotgraphic() {
-    const HotgraphicView = Adapt.getViewClass('hotgraphic');
+    const HotgraphicView = components.getViewClass('hotgraphic');
     if (!HotgraphicView) return;
 
     const model = this.prepareHotgraphicModel();
@@ -224,17 +228,17 @@ class NarrativeView extends ComponentView {
     this.$('.narrative__progress').removeClass('is-selected').filter(indexSelector).addClass('is-selected');
 
     const $slideGraphics = this.$('.narrative__slider-image-container');
-    Adapt.a11y.toggleAccessibleEnabled($slideGraphics, false);
-    Adapt.a11y.toggleAccessibleEnabled($slideGraphics.filter(indexSelector), true);
+    a11y.toggleAccessibleEnabled($slideGraphics, false);
+    a11y.toggleAccessibleEnabled($slideGraphics.filter(indexSelector), true);
 
     const $narrativeItems = this.$('.narrative__content-item');
     $narrativeItems.addClass('u-visibility-hidden u-display-none');
-    Adapt.a11y.toggleAccessible($narrativeItems, false);
-    Adapt.a11y.toggleAccessible($narrativeItems.filter(indexSelector).removeClass('u-visibility-hidden u-display-none'), true);
+    a11y.toggleAccessible($narrativeItems, false);
+    a11y.toggleAccessible($narrativeItems.filter(indexSelector).removeClass('u-visibility-hidden u-display-none'), true);
 
     const $narrativeStraplineButtons = this.$('.narrative__strapline-btn');
-    Adapt.a11y.toggleAccessibleEnabled($narrativeStraplineButtons, false);
-    Adapt.a11y.toggleAccessibleEnabled($narrativeStraplineButtons.filter(indexSelector), true);
+    a11y.toggleAccessibleEnabled($narrativeStraplineButtons, false);
+    a11y.toggleAccessibleEnabled($narrativeStraplineButtons.filter(indexSelector), true);
 
     this.evaluateNavigation();
     this.evaluateCompletion();
@@ -292,7 +296,7 @@ class NarrativeView extends ComponentView {
 
   openPopup() {
     const currentItem = this.model.getActiveItem();
-    Adapt.notify.popup({
+    notify.popup({
       title: currentItem.get('title'),
       body: currentItem.get('body')
     });

--- a/js/adapt-contrib-narrative.js
+++ b/js/adapt-contrib-narrative.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import NarrativeModel from './NarrativeModel';
 import NarrativeView from './NarrativeView';
 
-export default Adapt.register('narrative', {
+export default components.register('narrative', {
   model: NarrativeModel,
   view: NarrativeView
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "6.5.3",
-  "framework": ">=5.17.2",
+  "framework": ">=5.19.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component" : "narrative",


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to components.register from Adapt.register
* Use `a11y`, `device` and `notify` directly