### PR TITLE
Conflicting JSON configurations

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -250,4 +250,12 @@
   .items-are-full-width &__indicators {
     margin-bottom: @item-margin;
   }
+
+  // No Strapline 
+  // Settings for mobile when clickable elements are set in text area only
+  // --------------------------------------------------
+  .mode-small &__text-controls &__slide-container &__controls, 
+  .mode-small &__text-controls &__slide-indicators {
+    .u-display-none;
+  }
 }


### PR DESCRIPTION
Fixes issue present in #225 where "_hasNavigationInTextArea" visually conflicts with "_isMobileTextBelowImage" if both are set to true and when viewing on small screens.