### PR TITLE
issue/145 Automated aria heading levels

### DIFF
--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -12,7 +12,7 @@
 
           {{#if title}}
           <div class="narrative__content-title">
-            <div class="narrative__content-title-inner" {{a11y_attrs_heading 'componentItem'}}>
+            <div class="narrative__content-title-inner" role="heading" aria-level="{{a11y_aria_level @root/_id 'componentItem' _ariaLevel}}">
               {{{compile title}}}
             </div>
           </div>


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt-contrib-core/issues/145

### Changed
* `a11y_attrs_heading` to `a11y_aria_level`

requires https://github.com/adaptlearning/adapt-contrib-core/pull/146