### PR TITLE
Fix: Removed focus-rect (fixes #239)

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -38,17 +38,6 @@
     outline-offset: -5px;
   }
 
-  .ie &__strapline-btn:focus .focus-rect {
-    position: absolute;
-    right: 5px;
-    bottom: 5px;
-    top: 5px;
-    left: 5px;
-    outline-color: highlight;
-    outline-style: solid;
-    outline-width: 3px;
-  }
-
   &__strapline-title {
     display: block;
     margin-right: @icon-size + (@item-padding * 2);

--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -67,8 +67,6 @@
               <span class="icon"></span>
             </span>
 
-            <span class="focus-rect"></span>
-
           </button>
           {{/each}}
 


### PR DESCRIPTION
Fixes: #239 

### Fix
* Removed `focus-rect` element as it's no longer required
