### PR TITLE
Fix: Strapline overflow fix (fixes #245)

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -42,6 +42,8 @@
     display: block;
     margin-right: @icon-size + (@item-padding * 2);
     padding: @item-padding;
+    overflow: hidden;
+    text-overflow: ellipsis;
     // Override button line height to match icon size
     line-height: @icon-size;
 


### PR DESCRIPTION
Fixes: #245 

### Fix
* Introduced an ellipsis overflow for the narrative strapline title for when the text is longer than the display area
