### PR TITLE
Fix: Narrative item header level calculation

### DIFF
--- a/templates/narrative.jsx
+++ b/templates/narrative.jsx
@@ -6,6 +6,7 @@ import { templates, compile, classes } from 'core/js/reactHelpers';
 export default function Narrative(props) {
 
   const {
+    _id,
     _items,
     _translateXOffset,
     _hasNavigationInTextArea,
@@ -90,7 +91,7 @@ export default function Narrative(props) {
                   <div
                     className="narrative__content-title-inner"
                     role="heading"
-                    aria-level={a11y.ariaLevel({ level: 'componentItem', override: (_ariaLevel || null) })}
+                    aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem', override: (_ariaLevel || null) })}
                     dangerouslySetInnerHTML={{ __html: compile(title, props) }} />
                 </div>
                 }


### PR DESCRIPTION
issue #256 

### Fix
* Supplied id to a11y.ariaLevel calculation in order to find componentItem relative to component
