### PR TITLE
Fix: Move breakpoint to medium from large

### DIFF
--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -75,7 +75,7 @@ class NarrativeView extends ComponentView {
   }
 
   calculateMode() {
-    const mode = device.screenSize === 'large' ? MODE.LARGE : MODE.SMALL;
+    const mode = device.isScreenSizeMin('medium') ? MODE.LARGE : MODE.SMALL;
     this.model.set('_mode', mode);
     this.model.set('_isLargeMode', mode === MODE.LARGE);
   }
@@ -92,7 +92,7 @@ class NarrativeView extends ComponentView {
   }
 
   isTextBelowImage() {
-    const isTextBelowImage = (device.screenSize === 'large')
+    const isTextBelowImage = (device.isScreenSizeMin('medium'))
       ? this.model.get('_isTextBelowImage')
       : this.model.get('_isMobileTextBelowImage');
     return Boolean(isTextBelowImage);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "7.4.5",
-  "framework": ">=5.20.1",
+  "framework": ">=5.31.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component": "narrative",


### PR DESCRIPTION
fixes #263 

requires https://github.com/adaptlearning/adapt-contrib-core/pull/372

### Fix
* Move breakpoint to medium from large

Fw version should be bumped on merge of core code