### PR TITLE
Fix: Fix setFocus() when using _isMobileTextBelowImage (fixes #271)

### DIFF
--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -39,7 +39,7 @@ class NarrativeView extends ComponentView {
   }
 
   setFocus(itemIndex) {
-    const $animatedElement = this.isLargeMode()
+    const $animatedElement = this.isLargeMode() || this.model.get('_isMobileTextBelowImage')
       ? this.$('.narrative__slider')
       : this.$('.narrative__strapline-header-inner');
     const hasAnimation = ($animatedElement.css('transitionDuration') !== '0s');

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -55,9 +55,9 @@ class NarrativeView extends ComponentView {
 
   focusOnNarrativeElement(itemIndex) {
     const dataIndexAttr = `[data-index='${itemIndex}']`;
-    const $elementToFocus = this.isLargeMode() ?
-      this.$(`.narrative__content-item${dataIndexAttr}`) :
-      this.$(`.narrative__strapline-btn${dataIndexAttr}`);
+    const $elementToFocus = this.isLargeMode() || this.model.get('_isMobileTextBelowImage')
+      ? this.$(`.narrative__content-item${dataIndexAttr}`)
+      : this.$(`.narrative__strapline-btn${dataIndexAttr}`);
     a11y.focusFirst($elementToFocus);
     // Set button labels after focus to stop the change reading on a focused button
     this.setupBackNextLabels();


### PR DESCRIPTION
Fixes #271 

### Fix
* Fix the animatedElement target in setFocus() when using `_isMobileTextBelowImage`. The element `.narrative__strapline-header-inner` doesn't exist when using `_isMobileTextBelowImage: true` which is why it was breaking

### Testing
1. Enable `_isMobileTextBelowImage` in a Narrative component
2. Test on mobile
