### PR TITLE
Update: Remove _ariaLevel override property (fixes #283)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -123,15 +123,6 @@
             "help": "",
             "translatable": true
           },
-          "_ariaLevel": {
-            "type": "number",
-            "required": true,
-            "default": 0,
-            "title": "Narrative title level",
-            "inputType": "Number",
-            "validators": ["required", "number"],
-            "help": "Aria level for title"
-          },
           "body": {
             "type": "string",
             "required": false,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -91,11 +91,6 @@
                   "translatable": true
                 }
               },
-              "_ariaLevel": {
-                "type": "number",
-                "title": "Title ARIA level",
-                "default": 0
-              },
               "body": {
                 "type": "string",
                 "title": "Body",

--- a/templates/narrativeContent.jsx
+++ b/templates/narrativeContent.jsx
@@ -15,7 +15,7 @@ export default function Narrative(props) {
     <div className="narrative__content">
       <div className="narrative__content-inner">
 
-        {_items.map(({ _index, _isActive, _isVisited, title, body, _ariaLevel, _graphic }) =>
+        {_items.map(({ _index, _isActive, _isVisited, title, body, _graphic }) =>
 
           <div
             className={classes([
@@ -43,7 +43,7 @@ export default function Narrative(props) {
               <div
                 className="narrative__content-title-inner"
                 role="heading"
-                aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem', override: (_ariaLevel || null) })}
+                aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem' })}
                 dangerouslySetInnerHTML={{ __html: compile(title, props) }} />
             </div>
             }


### PR DESCRIPTION
Item title `_ariaLevel` override removed.

Since `_ariaLevels` were [automated in Core](https://github.com/adaptlearning/adapt-contrib-core/pull/146), there's no need to manually override these now.

Fixes https://github.com/adaptlearning/adapt-contrib-narrative/issues/283
