### PR TITLE
Fix: override default indicators width for _hasNavigationInTextArea display (fixes #291)

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -187,6 +187,7 @@
 
   &__text-controls &__content &__indicators {
     display: flex;
+    width: 100%;
   }
 
   &__text-controls &__content &__controls-container {


### PR DESCRIPTION
When `_hasNavigationInTextArea` display is enabled, the `.narrative__indicators` should span the width of their container, not inherit `width` from the default Narrative display (60% image / 40% text).

Current display:

<img width="949" alt="indicators_inherited_width" src="https://github.com/adaptlearning/adapt-contrib-narrative/assets/7045330/e1a71360-96d6-461f-bc3a-d5f5e569618b">


PR displays as:

<img width="938" alt="indicators_full_width" src="https://github.com/adaptlearning/adapt-contrib-narrative/assets/7045330/f8a8dd9f-f05d-40a6-a4aa-6a407983ed68">

Fixes https://github.com/adaptlearning/adapt-contrib-narrative/issues/291