### PR TITLE
Update: move previous/next item count ARIA outside of title condition (fixes #293)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}",
+      "default": "{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "next": {
       "type": "string",
       "required": true,
-      "default": "{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}",
+      "default": "{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}",
+                      "default": "{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
                       "_adapt": {
                         "translatable": true
                       }
@@ -40,7 +40,7 @@
                     "next": {
                       "type": "string",
                       "title": "Next",
-                      "default": "{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}",
+                      "default": "{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
                       "_adapt": {
                         "translatable": true
                       }


### PR DESCRIPTION
Including the item count e.g. _"Item 1 of 3"_, in the `.narrative__controls` `aria-label` was dependant on the item having a `title`. Item count now reads regardless. 

When `_items[].title` is set,`.narrative__controls` `aria-label` reads as _"Back to **item title** (item 1 of 3)"_.

When `_items[].title` is not set,`.narrative__controls` `aria-label` reads as _"Back (item 1 of 3)"_.

Fixes https://github.com/adaptlearning/adapt-contrib-narrative/issues/293