### PR TITLE
Fix: Keep active item position on save/restore (fixes #295)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "7.8.0",
-  "framework": ">=5.31.2",
+  "framework": ">=5.35.6",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component": "narrative",

--- a/js/NarrativeModel.js
+++ b/js/NarrativeModel.js
@@ -1,3 +1,24 @@
 import ItemsComponentModel from 'core/js/models/itemsComponentModel';
 
-export default class NarrativeModel extends ItemsComponentModel {}
+export default class NarrativeModel extends ItemsComponentModel {
+  restoreUserAnswers() {
+    const numberArray = this.get('_userAnswer');
+    if (!numberArray) return;
+    const children = this.getChildren();
+    const shouldRestoreActiveItem = (numberArray.length > children.length);
+    if (shouldRestoreActiveItem) {
+      const activeItemIndex = numberArray.pop();
+      this.setActiveItem(activeItemIndex);
+    }
+    children.forEach(child => child.set('_isVisited', Boolean(numberArray[child.get('_index')])));
+  }
+
+  storeUserAnswer() {
+    const items = this.getChildren().slice(0);
+    items.sort((a, b) => a.get('_index') - b.get('_index'));
+    const numberArray = items.map(child => child.get('_isVisited') ? 1 : 0);
+    const activeItem = this.getActiveItem();
+    if (activeItem) numberArray.push(activeItem.get('_index'));
+    this.set('_userAnswer', numberArray);
+  }  
+}

--- a/js/NarrativeModel.js
+++ b/js/NarrativeModel.js
@@ -21,9 +21,4 @@ export default class NarrativeModel extends ItemsComponentModel {
     if (activeItem) numberArray.push(activeItem.get('_index'));
     this.set('_userAnswer', numberArray);
   }
-
-  setActiveItem(index) {
-    super.setActiveItem(index);
-    this.storeUserAnswer();
-  }
 }

--- a/js/NarrativeModel.js
+++ b/js/NarrativeModel.js
@@ -20,5 +20,10 @@ export default class NarrativeModel extends ItemsComponentModel {
     const activeItem = this.getActiveItem();
     if (activeItem) numberArray.push(activeItem.get('_index'));
     this.set('_userAnswer', numberArray);
-  }  
+  }
+
+  setActiveItem(index) {
+    super.setActiveItem(index);
+    this.storeUserAnswer();
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "7.8.0",
-  "framework": ">=5.31.2",
+  "framework": ">=5.35.6",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component": "narrative",


### PR DESCRIPTION
fixes #295

### Fix
* Fix: Keep active item position on save/restore

Requires https://github.com/adaptlearning/adapt-contrib-core/pull/494