### PR TITLE
Fix: Title is required to set notify popup dialog label (fixes #297)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -115,11 +115,11 @@
         "properties": {
           "title": {
             "type": "string",
-            "required": false,
+            "required": true,
             "default": "",
             "title": "Narrative display title",
             "inputType": "Text",
-            "validators": [],
+            "validators": ["required"],
             "help": "",
             "translatable": true
           },


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-narrative/issues/297

### Fix
* Set `title` as `required`. Without a title, the popup `dialog` won't be properly identified by assistive technologies.