### PR TITLE
New: completion icon added to progress indicators (fixes #288) 

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -158,6 +158,7 @@
     width: @progress-size;
     margin: (@progress-size / 4);
     background-color: @background;
+    color: @background-inverted;
     border: @progress-border-size solid @background;
   }
 

--- a/less/narrative.less
+++ b/less/narrative.less
@@ -150,15 +150,28 @@
     }
   }
 
+  @progress-size: 1rem;
+  @progress-border-size: (@progress-size / 4) / 2;
+
   &__progress {
-    height: @icon-size / 2;
-    width: @icon-size / 2;
-    margin: 0.25rem;
+    height: @progress-size;
+    width: @progress-size;
+    margin: (@progress-size / 4);
     background-color: @background;
+    border: @progress-border-size solid @background;
   }
 
   &__progress.is-selected {
-    background-color: lighten(@background, 10%);
+    background-color: @background-inverted;
+    color: @background;
+  }
+
+  &__progress.is-visited .icon {
+    .icon-tick;
+
+    &:before {
+      font-size: @progress-size - (@progress-border-size * 2);
+    }
   }
 
   // When the disable animation class is not present add a transition effect

--- a/less/narrative.less
+++ b/less/narrative.less
@@ -185,7 +185,7 @@
     padding-top: @icon-size + (@icon-padding * 2) + @item-padding;
   }
 
-  &__text-controls &__content &__indicators {
+  .mode-small &__text-controls &__content &__indicators {
     display: flex;
     width: 100%;
   }
@@ -197,7 +197,7 @@
     right: 0;
     display: flex;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: flex-start;
   }
 
   &__text-controls &__content &__controls {
@@ -207,11 +207,10 @@
     transform: none;
   }
 
-  // Hide slide controls and indicators until single column view
+  // Hide slide controls until single column view
   // --------------------------------------------------
   @media (min-width: @device-width-medium) {
-    &__text-controls &__slide-container &__controls,
-    &__text-controls &__slide-indicators {
+    &__text-controls &__slide-container &__controls {
       .u-display-none;
     }
   }

--- a/less/narrative.less
+++ b/less/narrative.less
@@ -201,6 +201,7 @@
   .mode-small &__text-controls &__content &__indicators {
     display: flex;
     width: 100%;
+    margin-bottom: 0;
   }
 
   &__text-controls &__content &__controls-container {

--- a/templates/narrativeControls.jsx
+++ b/templates/narrativeControls.jsx
@@ -37,7 +37,7 @@ export default function NarrativeControls(props) {
         {_items.map(({ _index, _isVisited, _isActive }) =>
 
           <div className={classes([
-            'narrative__progress test-controls-jsx',
+            'narrative__progress',
             _isVisited && 'is-visited',
             _isActive && 'is-selected'
           ])}

--- a/templates/narrativeControls.jsx
+++ b/templates/narrativeControls.jsx
@@ -37,7 +37,7 @@ export default function NarrativeControls(props) {
         {_items.map(({ _index, _isVisited, _isActive }) =>
 
           <div className={classes([
-            'narrative__progress',
+            'narrative__progress test-controls-jsx',
             _isVisited && 'is-visited',
             _isActive && 'is-selected'
           ])}

--- a/templates/narrativeControls.jsx
+++ b/templates/narrativeControls.jsx
@@ -36,14 +36,17 @@ export default function NarrativeControls(props) {
       <div className="narrative__indicators">
         {_items.map(({ _index, _isVisited, _isActive }) =>
 
-          <div className={classes([
-            'narrative__progress',
-            _isVisited && 'is-visited',
-            _isActive && 'is-selected'
-          ])}
-          data-index={_index}
-          key={_index}
-          />
+          <div
+            className={classes([
+              'narrative__progress',
+              _isVisited && 'is-visited',
+              _isActive && 'is-selected'
+            ])}
+            data-index={_index}
+            key={_index}
+          >
+            <span className="icon" aria-hidden="true" />
+          </div>
 
         )}
       </div>

--- a/templates/narrativeIndicators.jsx
+++ b/templates/narrativeIndicators.jsx
@@ -24,7 +24,9 @@ export default function NarrativeIndicators(props) {
           ])}
           data-index={_index}
           key={_index}
-        />
+        >
+          <span className="icon" aria-hidden="true" />
+        </div>
       )}
 
     </div>


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-narrative/issues/288

### New
* Set progress indicator variables for consistent sizing.
* Progress indicator `border` and `.is-selected` styles added.
* Progress indicator `.is-visited` icon style added. Tick icon displayed for consistency with other visited component item states.

The overall `.narrative__progress` size has increased from 12px to 16px. The screen shots shared in the [issue](https://github.com/adaptlearning/adapt-contrib-narrative/issues/288#issuecomment-1866373034) have larger icons (`@icon-size` `1.5rem` for consistency with other component item visited ticks) however this limits the amount of items we can comfortably fit visually and the preference was to keep these small.

### Update
* Display progress indicators below the image always. When `_hasNavigationInTextArea` is enabled, displaying the indicators within the controls limits the space available for the indicators. Instead, display these consistently, below the image, across the various layout views. See [issue](https://github.com/adaptlearning/adapt-contrib-narrative/issues/288#issuecomment-1882879244) for discussion.
* Progress indicator margin replaced with variable (maintains same `0.25rem` value).

### Dependency
Vanilla [narrative.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/1d90e97fbafc75a095a6291073d0c31b3fd659ec/less/plugins/adapt-contrib-narrative/narrative.less#L22) will need updating to include `color` and `border-color` styles. I'll update the testing instructions when a Vanilla PR has been raised. [Issue](https://github.com/adaptlearning/adapt-contrib-vanilla/issues/509) raised.

### Testing
1. Install [issue/288](https://github.com/adaptlearning/adapt-contrib-narrative/tree/issue/288) branch.
2. Comment out `.narrative__progress` `background-color` styles in Vanilla [narrative.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/1d90e97fbafc75a095a6291073d0c31b3fd659ec/less/plugins/adapt-contrib-narrative/narrative.less#L22). For example:
```
  &__progress {
    //background-color: @item-color;
    border-radius: 50%;
  }

  // &__progress.is-visited {
  //   background-color: @visited;
  // }

  // &__progress.is-selected {
  //   background-color: @item-color-selected;
  // }
```
3. Test the following Narrative layouts on both large and small screen widths. Screen shots added for each configuration.

**In _component.json_, default layout:**

```
    "_hasNavigationInTextArea": false,
    "_isMobileTextBelowImage": false,
```
<img width="949" alt="large_default" src="https://github.com/adaptlearning/adapt-contrib-narrative/assets/7045330/9163eeec-fcab-47d4-8e46-2228064644a6">
<img width="373" alt="small_default" src="https://github.com/adaptlearning/adapt-contrib-narrative/assets/7045330/d2cb64c4-05ee-48fe-89a6-99c77a09b53a">


**Enable `_hasNavigationInTextArea`:**
<img width="957" alt="large_nav-in-text-area" src="https://github.com/adaptlearning/adapt-contrib-narrative/assets/7045330/b96a8b33-0f62-4b1a-bc20-28ef41890f16">


**Enable `_hasNavigationInTextArea` and `_isMobileTextBelowImage`:**
<img width="374" alt="small_nav-in-text-area_and_text-below-image" src="https://github.com/adaptlearning/adapt-contrib-narrative/assets/7045330/43c1ab14-3932-433a-9640-ed0c2bf6ffee">
^ mobile view (based on 375px screen width) supports 9 items before progress indicators are wrapped.



