### PR TITLE
Update: Make item titles optional, create fallback title for dialogs and strapline buttons (fixes #308)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -295,9 +295,21 @@ class NarrativeView extends ComponentView {
   }
 
   openPopup() {
+    const globals = Adapt.course.get('_globals');
+    const narrativeGlobals = globals._components._narrative;
+    const totalItems = this.model.getChildren().length;
     const currentItem = this.model.getActiveItem();
+    const index = currentItem.get('_index');
+    const defaultTitle = compile(narrativeGlobals.titleDialog, {
+      itemNumber: index + 1,
+      totalItems
+    });
+    const title = currentItem.get('title') || currentItem.get('strapline') || defaultTitle;
+    const isAltTitle = Boolean(!currentItem.get('title'));
+
     notify.popup({
-      title: currentItem.get('title'),
+      isAltTitle,
+      title,
       body: currentItem.get('body')
     });
 

--- a/properties.schema
+++ b/properties.schema
@@ -115,11 +115,11 @@
         "properties": {
           "title": {
             "type": "string",
-            "required": true,
+            "required": false,
             "default": "",
             "title": "Narrative display title",
             "inputType": "Text",
-            "validators": ["required"],
+            "validators": [],
             "help": "",
             "translatable": true
           },

--- a/properties.schema
+++ b/properties.schema
@@ -31,9 +31,19 @@
     "titleDialog": {
       "type": "string",
       "required": true,
-      "title": "Dialog title",
+      "title": "Dialog default title",
       "description": "Default fallback title to use for dialog popups when not set on an item",
       "default": "Item {{itemNumber}} of {{totalItems}}",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true
+    },
+    "titleStrapline": {
+      "type": "string",
+      "required": true,
+      "title": "Strapline default title",
+      "description": "Default fallback title to use for strapline buttons when not set on an item",
+      "default": "Find out more",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -27,6 +27,16 @@
       "inputType": "Text",
       "validators": [],
       "translatable": true
+    },
+    "titleDialog": {
+      "type": "string",
+      "required": true,
+      "title": "Dialog title",
+      "description": "Default fallback title to use for dialog popups when not set on an item",
+      "default": "Item {{itemNumber}} of {{totalItems}}",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true
     }
   },
   "properties": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -47,9 +47,18 @@
                     },
                     "titleDialog": {
                       "type": "string",
-                      "title": "Dialog title",
+                      "title": "Dialog default title",
                       "help": "Default fallback title to use for dialog popups when not set on an item",
                       "default": "Item {{itemNumber}} of {{totalItems}}",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "titleStrapline": {
+                      "type": "string",
+                      "title": "Strapline default title",
+                      "help": "Default fallback title to use for strapline buttons when not set on an item",
+                      "default": "Find out more",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -44,6 +44,15 @@
                       "_adapt": {
                         "translatable": true
                       }
+                    },
+                    "titleDialog": {
+                      "type": "string",
+                      "title": "Dialog title",
+                      "help": "Default fallback title to use for dialog popups when not set on an item",
+                      "default": "Item {{itemNumber}} of {{totalItems}}",
+                      "_adapt": {
+                        "translatable": true
+                      }
                     }
                   }
                 }

--- a/templates/narrativeStrapline.jsx
+++ b/templates/narrativeStrapline.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Adapt from 'core/js/adapt';
 import { compile, classes } from 'core/js/reactHelpers';
 
 export default function NarrativeStrapline(props) {
@@ -16,6 +17,8 @@ export default function NarrativeStrapline(props) {
   if (_isStackedOnMobile && !_isLargeMode) {
     return false;
   }
+
+  const globals = Adapt.course.get('_globals')._components._narrative;
 
   return (
     <div className="narrative__strapline">
@@ -48,7 +51,7 @@ export default function NarrativeStrapline(props) {
               <span className="narrative__strapline-title">
                 <span
                   className="narrative__strapline-title-inner"
-                  dangerouslySetInnerHTML={{ __html: compile(strapline || title, props) }}
+                  dangerouslySetInnerHTML={{ __html: compile(strapline || title || globals.titleStrapline, props) }}
                 />
               </span>
 


### PR DESCRIPTION
Fix #308 

### Update
* Make `_items` titles optional
* Adds new generic fallback title `_globals._components._narrative.titleDialog` for strapline dialogs. This will only be used by screenreaders and will not be visually displayed. Defaults to `Item {{itemNumber}} of {{totalItems}}`.
* Adds new generic fallback title `_globals._components._narrative.titleStrapline`  for strapline buttons. Defaults to "Find out more"

Rework strapline dialog titles to use one of the following properties (sorted by precedence):

1.  `_items` `title`
2. `_items` `strapline`
3. `_globals._components._narrative.titleDialog`

Rework strapline button titles to use one of the following properties (sorted by precedence):

1. `_items` `strapline`
2. `_items` `title`
3. `_globals._components._narrative.titleStrapline`