### PR TITLE
Fix: Change back and next button labels when at start / end (fixes #310)

### DIFF
--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -257,26 +257,27 @@ class NarrativeView extends ComponentView {
     const prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
     const nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
 
+    const prevBody = isAtStart ? '' : this.model.getItem(index - 1).get('body');
+    const nextBody = isAtEnd ? '' : this.model.getItem(index + 1).get('body');
+
     const backItem = isAtStart ? null : index;
     const nextItem = isAtEnd ? null : index + 2;
 
-    const backLabel = isAtStart ?
-      globals._accessibility._ariaLabels.previous :
-      compile(narrativeGlobals.previous, {
-        _globals: globals,
-        title: prevTitle,
-        itemNumber: backItem,
-        totalItems
-      });
+    const backLabel = compile(narrativeGlobals.previous, {
+      _globals: globals,
+      title: prevTitle,
+      body: prevBody,
+      itemNumber: backItem,
+      totalItems
+    });
 
-    const nextLabel = isAtEnd ?
-      globals._accessibility._ariaLabels.next :
-      compile(narrativeGlobals.next, {
-        _globals: globals,
-        title: nextTitle,
-        itemNumber: nextItem,
-        totalItems
-      });
+    const nextLabel = compile(narrativeGlobals.next, {
+      _globals: globals,
+      title: nextTitle,
+      body: nextBody,
+      itemNumber: nextItem,
+      totalItems
+    });
 
     this.model.set('backLabel', backLabel);
     this.model.set('nextLabel', nextLabel);

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -254,20 +254,21 @@ class NarrativeView extends ComponentView {
     const globals = Adapt.course.get('_globals');
     const narrativeGlobals = globals._components._narrative;
 
+    // !! WHY isn't the previous item here the same as backItem below? index - 1 vs. index
     const prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
     const nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
 
     const prevBody = isAtStart ? '' : this.model.getItem(index - 1).get('body');
     const nextBody = isAtEnd ? '' : this.model.getItem(index + 1).get('body');
 
-    const backItem = isAtStart ? null : index;
-    const nextItem = isAtEnd ? null : index + 2;
+    const prevItemNumber = isAtStart ? null : index;
+    const nextItemNumber = isAtEnd ? null : index + 2;
 
     const backLabel = compile(narrativeGlobals.previous, {
       _globals: globals,
       title: prevTitle,
       body: prevBody,
-      itemNumber: backItem,
+      itemNumber: prevItemNumber,
       totalItems
     });
 
@@ -275,7 +276,7 @@ class NarrativeView extends ComponentView {
       _globals: globals,
       title: nextTitle,
       body: nextBody,
-      itemNumber: nextItem,
+      itemNumber: nextItemNumber,
       totalItems
     });
 

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -254,7 +254,6 @@ class NarrativeView extends ComponentView {
     const globals = Adapt.course.get('_globals');
     const narrativeGlobals = globals._components._narrative;
 
-    // !! WHY isn't the previous item here the same as backItem below? index - 1 vs. index
     const prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
     const nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
 

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -258,10 +258,7 @@ class NarrativeView extends ComponentView {
     const nextItem = !_isAtEnd && this.model.getItem(index + 1);
 
     const prevTitle = prevItem ? prevItem.get('title') : '';
-    const prevBody = prevItem ? prevItem.get('body') : '';
-
     const nextTitle = nextItem ? nextItem.get('title') : '';
-    const nextBody = nextItem ? nextItem.get('body') : '';
 
     const prevItemNumber = _isAtStart ? null : index;
     const nextItemNumber = _isAtEnd ? null : index + 2;
@@ -269,7 +266,6 @@ class NarrativeView extends ComponentView {
     const backLabel = compile(narrativeGlobals.previous, {
       _globals,
       title: prevTitle,
-      body: prevBody,
       itemNumber: prevItemNumber,
       totalItems,
       _isAtStart
@@ -278,7 +274,6 @@ class NarrativeView extends ComponentView {
     const nextLabel = compile(narrativeGlobals.next, {
       _globals,
       title: nextTitle,
-      body: nextBody,
       itemNumber: nextItemNumber,
       totalItems,
       _isAtEnd

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -248,14 +248,14 @@ class NarrativeView extends ComponentView {
   setupBackNextLabels(index = this.model.getActiveItem().get('_index')) {
     const totalItems = this.model.getChildren().length;
 
-    const isAtStart = index === 0;
-    const isAtEnd = index === totalItems - 1;
+    const _isAtStart = index === 0;
+    const _isAtEnd = index === (totalItems - 1);
 
-    const globals = Adapt.course.get('_globals');
-    const narrativeGlobals = globals._components._narrative;
+    const _globals = Adapt.course.get('_globals');
+    const narrativeGlobals = _globals._components._narrative;
 
-    const prevItem = !isAtStart && this.model.getItem(index - 1);
-    const nextItem = !isAtEnd && this.model.getItem(index + 1);
+    const prevItem = !_isAtStart && this.model.getItem(index - 1);
+    const nextItem = !_isAtEnd && this.model.getItem(index + 1);
 
     const prevTitle = prevItem ? prevItem.get('title') : '';
     const prevBody = prevItem ? prevItem.get('body') : '';
@@ -263,23 +263,25 @@ class NarrativeView extends ComponentView {
     const nextTitle = nextItem ? nextItem.get('title') : '';
     const nextBody = nextItem ? nextItem.get('body') : '';
 
-    const prevItemNumber = isAtStart ? null : index;
-    const nextItemNumber = isAtEnd ? null : index + 2;
+    const prevItemNumber = _isAtStart ? null : index;
+    const nextItemNumber = _isAtEnd ? null : index + 2;
 
     const backLabel = compile(narrativeGlobals.previous, {
-      _globals: globals,
+      _globals,
       title: prevTitle,
       body: prevBody,
       itemNumber: prevItemNumber,
-      totalItems
+      totalItems,
+      _isAtStart
     });
 
     const nextLabel = compile(narrativeGlobals.next, {
-      _globals: globals,
+      _globals,
       title: nextTitle,
       body: nextBody,
       itemNumber: nextItemNumber,
-      totalItems
+      totalItems,
+      _isAtEnd
     });
 
     this.model.set('backLabel', backLabel);

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -247,19 +247,14 @@ class NarrativeView extends ComponentView {
    */
   setupBackNextLabels(index = this.model.getActiveItem().get('_index')) {
     const totalItems = this.model.getChildren().length;
-
     const _isAtStart = index === 0;
     const _isAtEnd = index === (totalItems - 1);
-
     const _globals = Adapt.course.get('_globals');
     const narrativeGlobals = _globals._components._narrative;
-
     const prevItem = !_isAtStart && this.model.getItem(index - 1);
     const nextItem = !_isAtEnd && this.model.getItem(index + 1);
-
     const prevTitle = prevItem ? prevItem.get('title') : '';
     const nextTitle = nextItem ? nextItem.get('title') : '';
-
     const prevItemNumber = _isAtStart ? null : index;
     const nextItemNumber = _isAtEnd ? null : index + 2;
 

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -254,34 +254,29 @@ class NarrativeView extends ComponentView {
     const globals = Adapt.course.get('_globals');
     const narrativeGlobals = globals._components._narrative;
 
-    let prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
-    let nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
+    const prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
+    const nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
 
-    let backItem = isAtStart ? null : index;
-    let nextItem = isAtEnd ? null : index + 2;
+    const backItem = isAtStart ? null : index;
+    const nextItem = isAtEnd ? null : index + 2;
 
-    if (isAtStart) {
-      prevTitle = this.model.getItem(totalItems - 1).get('title');
-      backItem = totalItems;
-    }
-    if (isAtEnd) {
-      nextTitle = this.model.getItem(0).get('title');
-      nextItem = 1;
-    }
+    const backLabel = isAtStart ?
+      globals._accessibility._ariaLabels.previous :
+      compile(narrativeGlobals.previous, {
+        _globals: globals,
+        title: prevTitle,
+        itemNumber: backItem,
+        totalItems
+      });
 
-    const backLabel = compile(narrativeGlobals.previous, {
-      _globals: globals,
-      title: prevTitle,
-      itemNumber: backItem,
-      totalItems
-    });
-
-    const nextLabel = compile(narrativeGlobals.next, {
-      _globals: globals,
-      title: nextTitle,
-      itemNumber: nextItem,
-      totalItems
-    });
+    const nextLabel = isAtEnd ?
+      globals._accessibility._ariaLabels.next :
+      compile(narrativeGlobals.next, {
+        _globals: globals,
+        title: nextTitle,
+        itemNumber: nextItem,
+        totalItems
+      });
 
     this.model.set('backLabel', backLabel);
     this.model.set('nextLabel', nextLabel);

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -251,10 +251,10 @@ class NarrativeView extends ComponentView {
     const _isAtEnd = index === (totalItems - 1);
     const _globals = Adapt.course.get('_globals');
     const narrativeGlobals = _globals._components._narrative;
-    const prevItem = !_isAtStart && this.model.getItem(index - 1);
-    const nextItem = !_isAtEnd && this.model.getItem(index + 1);
-    const prevTitle = prevItem ? prevItem.get('title') : '';
-    const nextTitle = nextItem ? nextItem.get('title') : '';
+    const prevItem = !_isAtStart ? this.model.getItem(index - 1) : null;
+    const nextItem = !_isAtEnd ? this.model.getItem(index + 1) : null;
+    const prevTitle = prevItem?.get('title') ?? '';
+    const nextTitle = nextItem?.get('title') ?? '';
     const prevItemNumber = _isAtStart ? null : index;
     const nextItemNumber = _isAtEnd ? null : index + 2;
 

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -254,11 +254,14 @@ class NarrativeView extends ComponentView {
     const globals = Adapt.course.get('_globals');
     const narrativeGlobals = globals._components._narrative;
 
-    const prevTitle = isAtStart ? '' : this.model.getItem(index - 1).get('title');
-    const nextTitle = isAtEnd ? '' : this.model.getItem(index + 1).get('title');
+    const prevItem = !isAtStart && this.model.getItem(index - 1);
+    const nextItem = !isAtEnd && this.model.getItem(index + 1);
 
-    const prevBody = isAtStart ? '' : this.model.getItem(index - 1).get('body');
-    const nextBody = isAtEnd ? '' : this.model.getItem(index + 1).get('body');
+    const prevTitle = prevItem ? prevItem.get('title') : '';
+    const prevBody = prevItem ? prevItem.get('body') : '';
+
+    const nextTitle = nextItem ? nextItem.get('title') : '';
+    const nextBody = nextItem ? nextItem.get('body') : '';
 
     const prevItemNumber = isAtStart ? null : index;
     const nextItemNumber = isAtEnd ? null : index + 2;

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -247,23 +247,23 @@ class NarrativeView extends ComponentView {
    */
   setupBackNextLabels(index = this.model.getActiveItem().get('_index')) {
     const totalItems = this.model.getChildren().length;
-    const _isAtStart = index === 0;
-    const _isAtEnd = index === (totalItems - 1);
+    const isAtStart = index === 0;
+    const isAtEnd = (index === totalItems - 1);
     const _globals = Adapt.course.get('_globals');
     const narrativeGlobals = _globals._components._narrative;
-    const prevItem = !_isAtStart ? this.model.getItem(index - 1) : null;
-    const nextItem = !_isAtEnd ? this.model.getItem(index + 1) : null;
+    const prevItem = isAtStart ? null : this.model.getItem(index - 1);
+    const nextItem = isAtEnd ? null : this.model.getItem(index + 1);
     const prevTitle = prevItem?.get('title') ?? '';
     const nextTitle = nextItem?.get('title') ?? '';
-    const prevItemNumber = _isAtStart ? null : index;
-    const nextItemNumber = _isAtEnd ? null : index + 2;
+    const prevItemNumber = isAtStart ? null : index;
+    const nextItemNumber = isAtEnd ? null : index + 2;
 
     const backLabel = compile(narrativeGlobals.previous, {
       _globals,
       title: prevTitle,
       itemNumber: prevItemNumber,
       totalItems,
-      _isAtStart
+      isAtStart
     });
 
     const nextLabel = compile(narrativeGlobals.next, {
@@ -271,7 +271,7 @@ class NarrativeView extends ComponentView {
       title: nextTitle,
       itemNumber: nextItemNumber,
       totalItems,
-      _isAtEnd
+      isAtEnd
     });
 
     this.model.set('backLabel', backLabel);

--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+      "default": "{{#any title body}}Back{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "next": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
+      "default": "{{#any title body}}Forward{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}{{#if title}} Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+      "default": "{{#any title body}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#if _isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
+      "default": "{{#if isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "next": {
       "type": "string",
       "required": true,
-      "default": "{{#if _isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
+      "default": "{{#if isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
+      "default": "{{#any title body}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "next": {
       "type": "string",
       "required": true,
-      "default": "{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
+      "default": "{{#any title body}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}Back{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+      "default": "{{#any title body}}{{#if title}} Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "next": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}Forward{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
+      "default": "{{#any title body}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -15,7 +15,7 @@
     "previous": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+      "default": "{{#if _isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "next": {
       "type": "string",
       "required": true,
-      "default": "{{#any title body}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
+      "default": "{{#if _isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#if _isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
+                      "default": "{{#if isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
                       "_adapt": {
                         "translatable": true
                       }
@@ -40,7 +40,7 @@
                     "next": {
                       "type": "string",
                       "title": "Next",
-                      "default": "{{#if _isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
+                      "default": "{{#if isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#any title body}}Back{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+                      "default": "{{#any title body}}{{#if title}} Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }
@@ -40,7 +40,7 @@
                     "next": {
                       "type": "string",
                       "title": "Next",
-                      "default": "{{#any title body}}Forward{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
+                      "default": "{{#any title body}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#any title body}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+                      "default": "{{#if _isAtStart}}{{_globals._accessibility._ariaLabels.previous}}{{else}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
                       "_adapt": {
                         "translatable": true
                       }
@@ -40,7 +40,7 @@
                     "next": {
                       "type": "string",
                       "title": "Next",
-                      "default": "{{#any title body}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
+                      "default": "{{#if _isAtEnd}}{{_globals._accessibility._ariaLabels.next}}{{else}}{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{/if}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
+                      "default": "{{#any title body}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }
@@ -40,7 +40,7 @@
                     "next": {
                       "type": "string",
                       "title": "Next",
-                      "default": "{{#if title}}Forward to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}} (item {{itemNumber}} of {{totalItems}})",
+                      "default": "{{#any title body}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#any title body}}{{#if title}} Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+                      "default": "{{#any title body}}{{#if title}}Back to {{{title}}}{{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "previous": {
                       "type": "string",
                       "title": "Previous",
-                      "default": "{{#any title body}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
+                      "default": "{{#any title body}}Back{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }
@@ -40,7 +40,7 @@
                     "next": {
                       "type": "string",
                       "title": "Next",
-                      "default": "{{#any title body}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
+                      "default": "{{#any title body}}Forward{{#if title}} to {{{title}}}{{/if}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/any}}",
                       "_adapt": {
                         "translatable": true
                       }


### PR DESCRIPTION
Fix #310

### Fix

* Changes Back button's `aria-label` to "Back" (`_globals._accessibility._ariaLabels.previous`) when on the first slide
* Changes Next button's `aria-label` to "Next" (`_globals._accessibility._ariaLabels.next`) when on the last slide
* Various code optimizations (e.g. renaming variables)

### Notes
These label values will need to be updated manually in existing courses.
