### PR TITLE
Fix: Use transitionsEnded function instead of transitionend event when setting focus (fixes #314)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "7.10.1",
-  "framework": ">=5.35.6",
+  "framework": ">=5.39.6",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component": "narrative",

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -7,6 +7,7 @@ import notify from 'core/js/notify';
 import ComponentView from 'core/js/views/componentView';
 import MODE from './modeEnum';
 import { compile } from 'core/js/reactHelpers';
+import { transitionsEnded } from 'core/js/transitions';
 
 class NarrativeView extends ComponentView {
 
@@ -40,15 +41,12 @@ class NarrativeView extends ComponentView {
     this.calculateWidths();
   }
 
-  setFocus(itemIndex) {
+  async setFocus(itemIndex) {
     const $animatedElement = this.isLargeMode() || this.model.get('_isMobileTextBelowImage')
       ? this.$('.narrative__slider')
       : this.$('.narrative__strapline-header-inner');
-    const hasAnimation = ($animatedElement.css('transitionDuration') !== '0s');
-    if (hasAnimation) {
-      $animatedElement.one('transitionend', () => this.focusOnNarrativeElement(itemIndex));
-      return;
-    }
+    await transitionsEnded($animatedElement);
+
     // Allow dom to settle before moving focus
     requestAnimationFrame(() => {
       this.focusOnNarrativeElement(itemIndex);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-narrative",
   "version": "7.10.1",
-  "framework": ">=5.35.6",
+  "framework": ">=5.39.6",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-narrative",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-narrative/issues",
   "component": "narrative",


### PR DESCRIPTION
Fix #314 

### Fix
* Use `transitionsEnded` function instead of the `transitionend` event when setting focus
* Bump required Adapt FW version to `5.39.6` due to use of `transitionsEnded`

### Testing
1. Ensure that repeatedly clicking Previous or Next does not shift the page contents due to the browser trying to find the offscreen element to focus on.
2. Ensure keyboard navigation + focus is still functional

