### PR TITLE
Fix: Ensure slide indicator icons are always centered (fix #325)

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -154,6 +154,9 @@
   @progress-border-size: (@progress-size / 4) / 2;
 
   &__progress {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
     height: @progress-size;
     width: @progress-size;
     margin: (@progress-size / 4);


### PR DESCRIPTION
Fixes #325

### Fix
* Ensure slide indicator icons are always centered both horizontally and vertically

**Correct**
<img width="170" src="https://github.com/user-attachments/assets/64b3aaa4-431c-4700-b88e-0b59bb6bc7ea" />

**Incorrect**
<img width="170" alt="Screenshot 2025-05-01 at 2 37 14 PM" src="https://github.com/user-attachments/assets/06a2894e-d2cd-4572-9c08-24672cf90c7e" />

