### PR TITLE
Fix: Narrative component registering as complete or partially complete before visiting (fixes #304)

### DIFF
--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -26,7 +26,6 @@ class NarrativeView extends ComponentView {
     this.model.set('_isInitial', true);
     this.model.set('_activeItemIndex', 0);
     this._isInview = false;
-    this._isFullyLoaded = false;
     this.onNavigationClicked = this.onNavigationClicked.bind(this);
     this.openPopup = this.openPopup.bind(this);
   }
@@ -127,7 +126,7 @@ class NarrativeView extends ComponentView {
   setupNarrative() {
     const items = this.model.getChildren();
     if (!items || !items.length) return;
-    
+
     let activeItem = this.model.getActiveItem();
     if (!activeItem) {
       activeItem = this.model.getItem(0);
@@ -136,7 +135,7 @@ class NarrativeView extends ComponentView {
       // manually trigger change as it is not fired on reentry
       items.trigger('change:_isActive', activeItem, true);
     }
-    
+
     this.calculateWidths();
     this.model.set('_isInitial', false);
   }

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -25,6 +25,8 @@ class NarrativeView extends ComponentView {
 
     this.model.set('_isInitial', true);
     this.model.set('_activeItemIndex', 0);
+    this.model.set('_isInview', false);
+    this.model.set('_isFullyLoaded', true);
     this.onNavigationClicked = this.onNavigationClicked.bind(this);
     this.openPopup = this.openPopup.bind(this);
   }
@@ -67,7 +69,7 @@ class NarrativeView extends ComponentView {
   onItemsActiveChange(item, _isActive) {
     if (!_isActive) return;
 
-    if (this.isTextBelowImage()) {
+    if (this.isTextBelowImage() && this.model.get('_isInview')) {
       item.toggleVisited(true);
     }
 
@@ -120,6 +122,7 @@ class NarrativeView extends ComponentView {
     this.setupNarrative();
     this.$('.narrative__slider').imageready(this.setReadyStatus.bind(this));
     this.$('.narrative__slide-container')[0]?.addEventListener('scroll', this.onScroll, true);
+    this.setupVisitedInview();
   }
 
   setupNarrative() {
@@ -214,7 +217,7 @@ class NarrativeView extends ComponentView {
   setStage(item) {
     const index = item.get('_index');
 
-    if (this.isLargeMode()) {
+    if (this.isLargeMode() && this.model.get('_isInview')) {
       item.toggleVisited(true);
     }
 
@@ -280,6 +283,18 @@ class NarrativeView extends ComponentView {
     if (this.model.areAllItemsCompleted()) {
       this.trigger('allItems');
       this.$('.narrative__instruction').removeClass('has-error');
+    }
+  }
+
+  inview() {
+    console.log('narrative inview');
+    this.model.set('_isInview', true);
+
+    const activeItem = this.model.getActiveItem()
+    if (!!activeItem) {
+      activeItem.toggleVisited(true);
+      
+      this.$('.component__widget').off('inview')
     }
   }
 
@@ -355,6 +370,10 @@ class NarrativeView extends ComponentView {
     if (!this.shouldUseInviewCompletion()) return;
 
     this.setupInviewCompletion('.component__widget');
+  }
+
+  setupVisitedInview() {
+    this.$('.component__widget').on('inview', _.throttle(_.bind(this.inview, this), 100));
   }
 
   preRemove() {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -122,7 +122,6 @@ class NarrativeView extends ComponentView {
     this.setupNarrative();
     this.$('.narrative__slider').imageready(this.setReadyStatus.bind(this));
     this.$('.narrative__slide-container')[0]?.addEventListener('scroll', this.onScroll, true);
-    this.setupVisitedInview();
   }
 
   setupNarrative() {
@@ -287,13 +286,9 @@ class NarrativeView extends ComponentView {
   }
 
   inview() {
-    console.log('narrative inview check');
     if (this.model.get('_isFullyLoaded') === false ) {
       this.model.set('_isFullyLoaded', true);
-      
-      // Then exit out of the inview function
     } else {
-      console.log('narrative inview');
       this.model.set('_isInview', true);
 
       const activeItem = this.model.getActiveItem()
@@ -377,9 +372,7 @@ class NarrativeView extends ComponentView {
     if (!this.shouldUseInviewCompletion()) return;
 
     this.setupInviewCompletion('.component__widget');
-  }
 
-  setupVisitedInview() {
     this.$('.component__widget').on('inview', _.throttle(_.bind(this.inview, this), 100));
   }
 

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -284,19 +284,21 @@ class NarrativeView extends ComponentView {
     }
   }
 
-  onInview() {
-    if (!this._isFullyLoaded) {
-      this._isFullyLoaded = true;
-      return;
-    }
+  onInview(event, isVisible) {
+    if (!isVisible) return;
+
     this._isInview = true;
     const activeItem = this.model.getActiveItem();
+
     if (activeItem) {
       activeItem.toggleVisited(true);
-      this.$('.component__widget').off('inview');
     }
-    if (!this.shouldUseInviewCompletion()) return;
-    this.setupInviewCompletion('.component__widget'); // Can you let me know if still works please? I'm unsure it will.
+
+    this.$('.component__widget').off('inview');
+
+    if (!this.shouldUseInviewCompletion()) return
+
+    this.setCompletionStatus();
   }
 
   openPopup() {
@@ -368,7 +370,7 @@ class NarrativeView extends ComponentView {
   }
 
   setupInviewVisited() {
-    this.$('.component__widget').on('inview', _.throttle(_.bind(this.inview, this), 100));
+    this.$('.component__widget').on('inview', _.debounce(_.bind(this.onInview, this), 100));
   }
 
   preRemove() {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -283,7 +283,7 @@ class NarrativeView extends ComponentView {
     }
   }
 
-  onInview(event, isVisible) {
+  onNarrativeInview(event, isVisible) {
     if (!isVisible) return;
 
     this._isInview = true;
@@ -297,7 +297,7 @@ class NarrativeView extends ComponentView {
 
     if (!this.shouldUseInviewCompletion()) return
 
-    this.setCompletionStatus();
+    this.setupInviewCompletion();
   }
 
   openPopup() {
@@ -369,7 +369,7 @@ class NarrativeView extends ComponentView {
   }
 
   setupInviewVisited() {
-    this.$('.component__widget').on('inview', _.debounce(_.bind(this.onInview, this), 100));
+    this.$('.component__widget').on('inview', _.debounce(_.bind(this.onNarrativeInview, this), 100));
   }
 
   preRemove() {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -369,7 +369,7 @@ class NarrativeView extends ComponentView {
   }
 
   setupInviewVisited() {
-    this.$('.component__widget').on('inview', _.debounce(_.bind(this.onNarrativeInview, this), 100));
+    this.$('.component__widget').on('inview', this.onNarrativeInview);
   }
 
   preRemove() {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -28,6 +28,7 @@ class NarrativeView extends ComponentView {
     this._isInview = false;
     this.onNavigationClicked = this.onNavigationClicked.bind(this);
     this.openPopup = this.openPopup.bind(this);
+    this.onNarrativeInview = this.onNarrativeInview.bind(this)
   }
 
   preRender() {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -287,6 +287,11 @@ class NarrativeView extends ComponentView {
   }
 
   inview() {
+    if (this.model.get('_isFullyLoaded') === false ); {
+      this.model.set('_isFullyLoaded', true);
+      return
+    }
+    
     console.log('narrative inview');
     this.model.set('_isInview', true);
 

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -284,20 +284,19 @@ class NarrativeView extends ComponentView {
     }
   }
 
-  inview() {
-    if (this._isFullyLoaded === false) {
+  onInview() {
+    if (!this._isFullyLoaded) {
       this._isFullyLoaded = true;
-    } else {
-      this._isInview = true;
-  
-      const activeItem = this.model.getActiveItem();
-      if (!!activeItem) {
-        activeItem.toggleVisited(true);
-        this.$('.component__widget').off('inview');
-      }
-
-      if (this.shouldUseInviewCompletion()) this.setupInviewCompletion('.component__widget');
+      return;
     }
+    this._isInview = true;
+    const activeItem = this.model.getActiveItem();
+    if (activeItem) {
+      activeItem.toggleVisited(true);
+      this.$('.component__widget').off('inview');
+    }
+    if (!this.shouldUseInviewCompletion()) return;
+    this.setupInviewCompletion('.component__widget'); // Can you let me know if still works please? I'm unsure it will.
   }
 
   openPopup() {

--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -26,7 +26,7 @@ class NarrativeView extends ComponentView {
     this.model.set('_isInitial', true);
     this.model.set('_activeItemIndex', 0);
     this.model.set('_isInview', false);
-    this.model.set('_isFullyLoaded', true);
+    this.model.set('_isFullyLoaded', false);
     this.onNavigationClicked = this.onNavigationClicked.bind(this);
     this.openPopup = this.openPopup.bind(this);
   }
@@ -287,19 +287,21 @@ class NarrativeView extends ComponentView {
   }
 
   inview() {
-    if (this.model.get('_isFullyLoaded') === false ); {
+    console.log('narrative inview check');
+    if (this.model.get('_isFullyLoaded') === false ) {
       this.model.set('_isFullyLoaded', true);
-      return
-    }
-    
-    console.log('narrative inview');
-    this.model.set('_isInview', true);
-
-    const activeItem = this.model.getActiveItem()
-    if (!!activeItem) {
-      activeItem.toggleVisited(true);
       
-      this.$('.component__widget').off('inview')
+      // Then exit out of the inview function
+    } else {
+      console.log('narrative inview');
+      this.model.set('_isInview', true);
+
+      const activeItem = this.model.getActiveItem()
+      if (!!activeItem) {
+        activeItem.toggleVisited(true);
+        
+        this.$('.component__widget').off('inview')
+      }
     }
   }
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #304 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Sets an inview toggle before registering an item as visited
