### PR TITLE
Fix: Guard against missing graphic in slide container template (fixes #335)

### DIFF
--- a/templates/narrativeSlideContainer.jsx
+++ b/templates/narrativeSlideContainer.jsx
@@ -39,7 +39,7 @@ export default function NarrativeSlideContainer(props) {
               'narrative__slider-image-container',
               _isActive && 'is-active',
               _isVisited && 'is-visited',
-              _graphic.attribution && 'has-attribution'
+              _graphic?.attribution && 'has-attribution'
             ])}
             style={{ width: `${_itemWidth}%` }}
             aria-hidden={!_isActive || null}
@@ -47,11 +47,12 @@ export default function NarrativeSlideContainer(props) {
             key={_index}
           >
 
+            {_graphic &&
             <templates.image {..._graphic}
               classNamePrefixes={['narrative__slider-image js-narrative-swipe']}
               attributionClassNamePrefixes={['component', 'narrative']}
               draggable="false"
-            />
+            />}
 
           </div>
 


### PR DESCRIPTION
Fixes #335

### Fix
* Use optional chaining (`_graphic?.attribution`) to prevent TypeError when `_graphic` is undefined
* Wrap `templates.image` render in a `_graphic &&` guard to prevent spreading an undefined object

### Testing
1. Create a narrative component with one or more items that have no graphic set
2. Preview the course and navigate to the narrative
3. Verify no attribution errors appear in the console
4. Verify items with graphics still render correctly