### PR TITLE
Fix: Prevent Adapt.on('popup:opened') listener leak in openPopup (fixes #345)

### DIFF
--- a/js/NarrativeView.js
+++ b/js/NarrativeView.js
@@ -29,12 +29,14 @@ class NarrativeView extends ComponentView {
     this.onNavigationClicked = this.onNavigationClicked.bind(this);
     this.openPopup = this.openPopup.bind(this);
     this.onInview = this.onInview.bind(this);
+    this.onPopupOpened = this.onPopupOpened.bind(this);
   }
 
   preRender() {
     this.listenTo(Adapt, {
       'device:changed device:resize': this.reRender,
-      'notify:closed': this.closeNotify
+      'notify:closed': this.closeNotify,
+      'popup:opened': this.onPopupOpened
     });
     this.renderMode();
 
@@ -310,16 +312,19 @@ class NarrativeView extends ComponentView {
     const title = currentItem.get('title') || currentItem.get('strapline') || defaultTitle;
     const isAltTitle = Boolean(!currentItem.get('title'));
 
-    notify.popup({
+    this._popupView = notify.popup({
       isAltTitle,
       title,
       body: currentItem.get('body')
     });
+    this._popupActiveItem = currentItem;
+  }
 
-    Adapt.on('popup:opened', function() {
-      // Set the visited attribute for small and medium screen devices
-      currentItem.toggleVisited(true);
-    });
+  onPopupOpened($element) {
+    // Ignore popups that didn't originate from this narrative's openPopup
+    if (!this._popupView || !$element.closest(this._popupView.el).length) return;
+    // Set the visited attribute for small and medium screen devices
+    this._popupActiveItem.toggleVisited(true);
   }
 
   onNavigationClicked(e) {


### PR DESCRIPTION
Fixes #345

### Fix
* Bind the `popup:opened` handler once via `this.listenTo(Adapt, ...)` in `preRender()`, instead of calling `Adapt.on()` inside `openPopup()` on every invocation — Backbone unbinds it automatically when the view is removed
* Only mark the active item visited when the opened popup is the one this narrative instance created, matched against the `NotifyPopupView` returned by `notify.popup()`, instead of reacting to any popup opened anywhere in the course

### Testing
1. Add a narrative component with items that have titles/straplines set, and preview the course
2. Open and close a narrative item's popup several times; confirm `Adapt._events['popup:opened'].length` no longer grows
3. While a narrative item is visible, trigger an unrelated popup elsewhere (e.g. another component's `notify.popup()`/alert) and confirm the narrative item's visited state is unaffected
4. Confirm normal behaviour still works: opening a narrative item's own popup still marks that item visited